### PR TITLE
Improve attribute support

### DIFF
--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -703,7 +703,7 @@ class MychScriptContext
             break;
         }
         
-        if (!lookupObj || !lookupKey)
+        if (!lookupObj)
         {
             return undefined;
         }
@@ -711,6 +711,11 @@ class MychScriptContext
         if (!this.$canViewAttribute(lookupObj, attributeName))
         {
             return this.$getDenied();
+        }
+
+        if (!lookupKey)
+        {
+            return undefined;
         }
 
         return lookupObj.get(lookupKey);

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -314,7 +314,7 @@ class MychScriptContext
 
     chat(message)
     {
-        var character = this.$getcharobj(this.sender);
+        var [character, token] = this.$getCharacterAndTokenObjs(this.sender);
 
         if (character)
         {

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -627,6 +627,7 @@ class MychScriptContext
 
         var lookupObj = undefined;
         var lookupKey = undefined;
+        var lookupMod = val => val;
 
         switch (attributeName)
         {
@@ -686,6 +687,7 @@ class MychScriptContext
                 {
                     lookupObj = getObj("page", Campaign().get("playerpageid"));
                     lookupKey = (attributeName == "left" ? "width" : "height");
+                    lookupMod = val => 70 * val;
                 }
                 else
                 {
@@ -721,7 +723,7 @@ class MychScriptContext
             return undefined;
         }
 
-        return lookupObj.get(lookupKey);
+        return lookupMod(lookupObj.get(lookupKey));
     }
 
     $setAttribute(nameOrId, attributeName, attributeValue, max = false)
@@ -789,9 +791,7 @@ class MychScriptContext
             {
                 if (max)
                 {
-                    updateObj = getObj("page", Campaign().get("playerpageid"));
-                    updateKey = (attributeName == "left" ? "width" : "height");
-                    updateVal = MychExpression.coerceNumber(attributeValue);
+                    // changing page dimensions through token intentionally unsupported
                 }
                 else
                 {
@@ -829,7 +829,7 @@ class MychScriptContext
 
         updateObj.set(updateKey, updateVal);
 
-        return updateObj.get(updateKey);
+        return this.$getAttribute(nameOrId, attributeName, max);
     }
 }
 

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -337,6 +337,12 @@ class MychScriptContext
         sendChat("Mych's Macro Magic", "/direct " + exception, null, { noarchive: true });
     }
 
+    getcharid(nameOrId)
+    {
+        var [character, token] = this.$getCharacterAndTokenObjs(nameOrId);
+        return (character ? character.id : undefined);
+    }
+
     getattr(nameOrId, attributeName)
     {
         return this.$getAttribute(nameOrId, attributeName, false);

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -601,8 +601,8 @@ class MychScriptContext
     {
         var denied =
         {
-            getScalar: () => undefined,
-            getMarkup: () => "<span style=\"background: red; border: 2px solid red; color: white; font-weight: bold\">denied</span>",
+            toScalar: () => undefined,
+            toMarkup: () => "<span style=\"background: red; border: 2px solid red; color: white; font-weight: bold\">denied</span>",
         };
 
         return denied;

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -373,8 +373,9 @@ class MychScriptContext
 
         if (objType == "attribute")
         {
-            var characterId = obj.get("characterid");
-            return this.$canControl(getObj("character", characterId));
+            var ownerCharacterId = obj.get("characterid");
+            var ownerCharacter = getObj("character", ownerCharacterId);
+            return this.$canControl(ownerCharacter);
         }
 
         if (objType == "hand" && obj.get("parentid") == this.playerid)
@@ -383,11 +384,12 @@ class MychScriptContext
         }
 
         // objType == "graphic"
-        var representsPlayerId = obj.get("represents");
+        var representsCharacterId = obj.get("represents");
 
-        if (representsPlayerId && representsPlayerId == this.playerid)
+        if (representsCharacterId)
         {
-            return true;
+            var representsCharacter = getObj("character", representsCharacterId);
+            return this.$canControl(representsCharacter);
         }
 
         // objType == "path", "text", "graphic", "character"

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -1,7 +1,7 @@
 // Mych's Macro Magic by Michael Buschbeck <michael@buschbeck.net> (2021)
 // https://github.com/michael-buschbeck/mychs-macro-magic/blob/main/LICENSE
 
-const MMM_VERSION = "1.2.1";
+const MMM_VERSION = "1.3.0";
 
 on("chat:message", function(msg)
 {
@@ -337,158 +337,491 @@ class MychScriptContext
         sendChat("Mych's Macro Magic", "/direct " + exception, null, { noarchive: true });
     }
 
-    $permission(obj)
+    getattr(nameOrId, attributeName)
     {
-        if (!this.playerid || !obj || typeof(obj.get) != "function")
+        return this.$getAttribute(nameOrId, attributeName, false);
+    }
+
+    getattrmax(nameOrId, attributeName)
+    {
+        return this.$getAttribute(nameOrId, attributeName, true);
+    }
+
+    setattr(nameOrId, attributeName, attributeValue)
+    {
+        return this.$setAttribute(nameOrId, attributeName, attributeValue, false);
+    }
+
+    setattrmax(nameOrId, attributeName, attributeValue)
+    {
+        return this.$setAttribute(nameOrId, attributeName, attributeValue, true);
+    }
+
+    $canControl(obj)
+    {
+        if (!this.playerid || !obj || !obj.get)
         {
-            return "none";
+            return undefined;
         }
 
         if (playerIsGM(this.playerid))
         {
-            return "control";
+            return true;
         }
 
-        if ((obj.get("_parentid") || "") == this.playerid)
+        var objType = obj.get("type");
+
+        if (objType == "attribute")
         {
-            return "control";
+            var characterId = obj.get("characterid");
+            return this.$canControl(getObj("character", characterId));
         }
 
-        if ((obj.get("represents") || "") == this.playerid)
+        if (objType == "hand" && obj.get("parentid") == this.playerid)
         {
-            return "control";
+            return true;
         }
 
-        if ((obj.get("controlledby") || "").split(",").some(id => id == "all" || id == this.playerid))
+        // objType == "graphic"
+        var representsPlayerId = obj.get("represents");
+
+        if (representsPlayerId && representsPlayerId == this.playerid)
         {
-            return "control";
+            return true;
         }
 
-        if ((obj.get("inplayerjournals") || "").split(",").some(id => id == "all" || id == this.playerid))
+        // objType == "path", "text", "graphic", "character"
+        var controllerPlayerIds = obj.get("controlledby");
+
+        if (controllerPlayerIds && controllerPlayerIds.split(",").some(id => id == "all" || id == this.playerid))
         {
-            return "view";
+            return true;
         }
 
-        if ((obj.get("_pageid") || "") == Campaign().get("playerpageid") && ["objects", "maps"].includes(obj.get("layer")))
-        {
-            return "view";
-        }
-
-        return "none";
+        return false;
     }
 
-    $cancontrol(obj)
+    $canControlAttribute(obj, attributeName)
     {
-        return ["control"].includes(this.$permission(obj));
+        return this.$canControl(obj);
     }
 
-    $canview(obj)
+    $canView(obj)
     {
-        return ["control", "view"].includes(this.$permission(obj));
-    }
-
-    $getcharobj(characterNameOrId)
-    {
-        if (/^-/.test(characterNameOrId))
+        if (!this.playerid || !obj || !obj.get)
         {
-            var character = getObj("character", characterNameOrId);
+            return false;
+        }
 
-            if (character)
+        if (this.$canControl(obj))
+        {
+            return true;
+        }
+
+        var objType = obj.get("type");
+
+        if (objType == "attribute")
+        {
+            var characterId = obj.get("characterid");
+            return this.$canView(getObj("character", characterId));
+        }
+
+        var playerPageId = Campaign().get("playerpageid");
+
+        if (objType == "page" && obj.id == playerPageId)
+        {
+            return true;
+        }
+
+        // objType == "character", "handout"
+        var journalPlayerIds = obj.get("inplayerjournals");
+
+        if (journalPlayerIds && journalPlayerIds.split(",").some(id => id == "all" || id == this.playerid))
+        {
+            return true;
+        }
+
+        // objType == "text", "path", "graphic"
+        var drawingPageId = obj.get("pageid");
+
+        if (drawingPageId && drawingPageId == playerPageId)
+        {
+            var drawingLayer = obj.get("layer");
+            return (drawingLayer == "objects" || drawingLayer == "maps");
+        }
+
+        return false;
+    }
+
+    $canViewAttribute(obj, attributeName)
+    {
+        if (attributeName == "permission")
+        {
+            return true;
+        }
+
+        if (this.$canControlAttribute(obj, attributeName))
+        {
+            return true;
+        }
+
+        if (this.$canView(obj))
+        {
+            switch (attributeName)
             {
+                case "id":
+                case "character_id":
+                case "token_id":
+                {
+                    return true;
+                }
+
+                case "name":
+                case "character_name":
+                case "token_name":
+                {
+                    var token = this.$getCorrespondingTokenObj(obj);
+                    return (token && token.get("showplayers_name"));
+                }
+
+                case "bar1":
+                case "bar2":
+                case "bar3":
+                {
+                    var token = this.$getCorrespondingTokenObj(obj);
+                    return (token && token.get("showplayers_" + attributeName));
+                }
+
+                case "left":
+                case "top":
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    $getCorrespondingTokenObj(characterOrToken)
+    {
+        if (!characterOrToken || !characterOrToken.get)
+        {
+            return undefined;
+        }
+
+        switch (characterOrToken.get("type"))
+        {
+            case "graphic":
+            {
+                return characterOrToken;
+            }
+
+            case "character":
+            {
+                var tokens = findObjs({ type: "graphic", subtype: "token", represents: characterOrToken.id, pageid: Campaign().get("playerpageid") });
+                return (tokens ? tokens[0] : undefined);
+            }
+        }
+
+        return undefined;
+    }    
+
+    $getCorrespondingCharacterObj(characterOrToken)
+    {
+        if (!characterOrToken || !characterOrToken.get)
+        {
+            return undefined;
+        }
+
+        switch (characterOrToken.get("type"))
+        {
+            case "character":
+            {
+                return characterOrToken;
+            }
+
+            case "graphic":
+            {
+                var character = getObj("character", characterOrToken.get("represents"));
                 return character;
             }
         }
 
-        var characters = findObjs({ _type: "character", name: characterNameOrId });
-        return characters[0];
-    }
-    
-    $getattrobj(character, attributeName)
+        return undefined;
+    }    
+
+    $getCharacterAndTokenObjs(nameOrId)
     {
-        if (!character || character.get("_type") != "character" || !this.$cancontrol(character))
+        var characterOrToken =
+            getObj("character", nameOrId) ||
+            getObj("graphic", nameOrId);
+
+        if (!this.$canView(characterOrToken))
+        {
+            characterOrToken = undefined;
+        }
+
+        if (!characterOrToken)
+        {
+            characterOrToken =
+                findObjs({ type: "character", name: nameOrId }).filter(obj => this.$canViewAttribute(obj, "name"))[0] ||
+                findObjs({ type: "graphic", name: nameOrId }).filter(obj => this.$canViewAttribute(obj, "name"))[0];
+        }
+
+        if (!characterOrToken)
+        {
+            return [undefined, undefined];
+        }
+
+        var character = undefined;
+        var token = undefined;
+
+        switch (characterOrToken.get("type"))
+        {
+            case "character":
+            {
+                character = characterOrToken;
+                token = this.$getCorrespondingTokenObj(characterOrToken);
+            }
+            break;
+
+            case "graphic":
+            {
+                character = this.$getCorrespondingCharacterObj(characterOrToken);
+                token = characterOrToken;
+            }
+            break;
+        }
+
+        return [character, token];
+    }
+
+    $getDenied()
+    {
+        var denied =
+        {
+            getScalar: () => undefined,
+            getMarkup: () => "<span style=\"background: red; border: 2px solid red; color: white; font-weight: bold\">denied</span>",
+        };
+
+        return denied;
+    }
+
+    $getAttribute(nameOrId, attributeName, max = false)
+    {
+        var [character, token] = this.$getCharacterAndTokenObjs(nameOrId);
+
+        if (!character && !token)
+        {
+            if (attributeName == "permission")
+            {
+                return "none";
+            }
+
+            return this.$getDenied();
+        }
+
+        var lookupObj = undefined;
+        var lookupKey = undefined;
+
+        switch (attributeName)
+        {
+            case "permission":
+            {
+                return (this.$canControl(character || token) ? "control" : "view");
+            }
+
+            case "name":
+            {
+                lookupObj = character || token;
+                lookupKey = (max ? undefined : "name");
+            }
+            break;
+                
+            case "character_name":
+            {
+                lookupObj = character;
+                lookupKey = (max ? undefined : "name");
+            }
+            break;
+            
+            case "token_name":
+            {
+                lookupObj = token;
+                lookupKey = (max ? undefined : "name");
+            }
+            break;
+
+            case "character_id":
+            {
+                lookupObj = character;
+                lookupKey = (max ? undefined : "id");
+            }
+            break;
+
+            case "token_id":
+            {
+                lookupObj = token;
+                lookupKey = (max ? undefined : "id");
+            }
+            break;
+        
+            case "bar1":
+            case "bar2":
+            case "bar3":
+            {
+                lookupObj = token;
+                lookupKey = attributeName + (max ? "_max" : "_value");
+            }
+            break;
+
+            case "left":
+            case "top":
+            {
+                if (max)
+                {
+                    lookupObj = getObj("page", Campaign().get("playerpageid"));
+                    lookupKey = (attributeName == "left" ? "width" : "height");
+                }
+                else
+                {
+                    lookupObj = token;
+                    lookupKey = attributeName;
+                }
+            }
+            break;
+
+            default:
+            {
+                if (character)
+                {
+                    lookupObj = findObjs({ type: "attribute", characterid: character.id, name: attributeName })[0];
+                    lookupKey = (max ? "max" : "current");
+                }
+            }
+            break;
+        }
+        
+        if (!lookupObj || !lookupKey)
         {
             return undefined;
         }
 
-        var attributes = findObjs({ _type: "attribute", _characterid: character.id, name: attributeName });
-        return attributes[0];
+        if (!this.$canViewAttribute(lookupObj, attributeName))
+        {
+            return this.$getDenied();
+        }
+
+        return lookupObj.get(lookupKey);
     }
 
-    $createattrobj(character, attributeName)
+    $setAttribute(nameOrId, attributeName, attributeValue, max = false)
     {
-        if (!character || character.get("_type") != "character" || !this.$cancontrol(character))
+        var [character, token] = this.$getCharacterAndTokenObjs(nameOrId);
+
+        if (!character && !token)
+        {
+            return this.$getDenied();
+        }
+
+        var updateObj = undefined;
+        var updateKey = undefined;
+        var updateVal = undefined;
+
+        switch (attributeName)
+        {
+            case "permission":
+            {
+                return this.$getDenied();
+            }
+
+            case "name":
+            {
+                updateObj = character || token;
+            }
+            break;
+                
+            case "character_name":
+            {
+                updateObj = character;
+            }
+            break;
+            
+            case "token_name":
+            {
+                updateObj = token;
+            }
+            break;
+
+            case "character_id":
+            {
+                updateObj = character;
+            }
+            break;
+
+            case "token_id":
+            {
+                updateObj = token;
+            }
+            break;
+        
+            case "bar1":
+            case "bar2":
+            case "bar3":
+            {
+                updateObj = token;
+                updateKey = attributeName + (max ? "_max" : "_value");
+                updateVal = MychExpression.coerceNumber(attributeValue);
+            }
+            break;
+
+            case "left":
+            case "top":
+            {
+                if (max)
+                {
+                    updateObj = getObj("page", Campaign().get("playerpageid"));
+                    updateKey = (attributeName == "left" ? "width" : "height");
+                    updateVal = MychExpression.coerceNumber(attributeValue);
+                }
+                else
+                {
+                    updateObj = token;
+                    updateKey = attributeName;
+                    updateVal = MychExpression.coerceNumber(attributeValue);
+                }
+            }
+            break;
+
+            default:
+            {
+                if (character && this.$canControlAttribute(character, attributeName))
+                {
+                    updateObj =
+                        findObjs({ type: "attribute", characterid: character.id, name: attributeName })[0] ||
+                        createObj("attribute", { characterid: character.id, name: attributeName });
+
+                    updateKey = (max ? "max" : "current");
+                    updateVal = MychExpression.coerceScalar(attributeValue);
+                }
+            }
+            break;
+        }
+        
+        if (!updateObj)
         {
             return undefined;
         }
 
-        return createObj("attribute", { _characterid: character.id, name: attributeName });
-    }
-
-    getattr(characterNameOrId, attributeName)
-    {
-        var character = this.$getcharobj(characterNameOrId);
-
-        if (attributeName == "permission")
+        if (!updateKey || !this.$canControlAttribute(updateObj, attributeName))
         {
-            return this.$permission(character);
+            return this.$getDenied();
         }
 
-        if (character && attributeName == "character_id")
-        {
-            return character.id;
-        }
+        updateObj.set(updateKey, updateVal);
 
-        if (character && attributeName == "character_name")
-        {
-            return character.get("name");
-        }
-
-        var attribute = this.$getattrobj(character, attributeName);
-        return attribute ? attribute.get("current") : undefined;
-    }
-
-    getattrmax(characterNameOrId, attributeName)
-    {
-        var character = this.$getcharobj(characterNameOrId);
-        var attribute = this.$getattrobj(character, attributeName);
-
-        return attribute ? attribute.get("max") : undefined;
-    }
-
-    setattr(characterNameOrId, attributeName, attributeValue)
-    {
-        var character = this.$getcharobj(characterNameOrId);
-
-        if (!this.$cancontrol(character) || ["permission", "character_id", "character_name"].includes(attributeName))
-        {
-            return this.getattr(character, attributeName);
-        }
-
-        var attribute =
-            this.$getattrobj(character, attributeName) ||
-            this.$createattrobj(character, attributeName);
-
-        attribute.set("current", MychExpression.coerceScalar(attributeValue));
-
-        return attribute.get("current");
-    }
-
-    setattrmax(characterNameOrId, attributeName, attributeValue)
-    {
-        var character = this.$getcharobj(characterNameOrId);
-
-        if (!this.$cancontrol(character) || ["permission", "character_id", "character_name"].includes(attributeName))
-        {
-            return this.getattrmax(character, attributeName);
-        }
-
-        var attribute =
-            this.$getattrobj(character, attributeName) ||
-            this.$createattrobj(character, attributeName);
-
-        attribute.set("max", MychExpression.coerceScalar(attributeValue));
-
-        return attribute.get("max");
+        return updateObj.get(updateKey);
     }
 }
 

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -521,7 +521,8 @@ class MychScriptContext
 
             case "character":
             {
-                var tokens = findObjs({ type: "graphic", subtype: "token", represents: characterOrToken.id, pageid: Campaign().get("playerpageid") });
+                var playerPageId = Campaign().get("playerpageid");
+                var tokens = findObjs({ type: "graphic", subtype: "token", represents: characterOrToken.id, pageid: playerPageId });
                 return (tokens ? tokens[0] : undefined);
             }
         }

--- a/README.md
+++ b/README.md
@@ -279,12 +279,12 @@ MMM has a more general notion of what attributes are than Roll20 itself and adds
 
 | Attribute         | Example              | Value? | Max?  | Description
 | ----------------- | -------------------- | ------ | ----- | -----------
-| `permission`      | `"control"`          | read   | —     | `"none"`, `"view"`, or `"control"` – see below
-| `name`            | `"Finn"`             | read   | —     | Character or token name
-| `token_id`        |                      | read   | —     | Token ID
-| `token_name`      | `"Finn's Spiderbro"` | read   | —     | Token name – provided for Roll20 parity
-| `character_id`    |                      | read   | —     | Character ID
-| `character_name`  | `"Finn"`             | read   | —     | Character name – provided for Roll20 parity
+| `permission`      | `"control"`          | read   |       | `"none"`, `"view"`, or `"control"` – see below
+| `name`            | `"Finn"`             | read   |       | Character or token name
+| `token_id`        |                      | read   |       | Token ID
+| `token_name`      | `"Finn's Spiderbro"` | read   |       | Token name – provided for Roll20 parity
+| `character_id`    |                      | read   |       | Character ID
+| `character_name`  | `"Finn"`             | read   |       | Character name – provided for Roll20 parity
 | `bar1`            | `20` / `30`          | write  | write | Token's top bar value – middle circle (default green)
 | `bar2`            | `20` / `30`          | write  | write | Token's middle bar value – right circle (default blue)
 | `bar3`            | `20` / `30`          | write  | write | Token's bottom bar value – left circle (default red)

--- a/README.md
+++ b/README.md
@@ -332,27 +332,27 @@ If you want to calculate the square root of something, you can use the power-of 
 
 ### Functions
 
-| Syntax                              | Category  | Example | Description
-| ----------------------------------- | --------- | ------- | -----------
-| floor(*a*)                          | Math      | floor(1.7) = 1 | Return the greatest integer that's less than or equal to *a*
-| round(*a*)                          | Math      | round(1.5) = 2 | Round *a* to the nearest integer
-| ceil(*a*)                           | Math      | ceil(1.3) = 2  | Return the smallest integer that's greater than or equal to *a*
-| abs(*a*)                            | Math      | abs(-5) = 5    | Return the absolute value of *a*
-| min(...)                            | Math      | min(3,1,2) = 1 | Return the numerically smallest value – any number of arguments allowed
-| max(...)                            | Math      | max(3,1,2) = 3 | Return the numerically greatest value – any number of arguments allowed
-| len(*str*)                          | String    | len("foo") = 3 | Return the number of character in string *str*
-| literal(*str*)                      | String    | literal("1<2") = "1\&lt;2" | Escape all HTML control characters in string *str*
-| highlight(*str*)                    | String    |  | When output to chat, highlight string *str* with a pretty box
-| highlight(*str*, *type*)            | String    |  | ...with a colored outline depending on *type* = "normal", "important", "good", "bad"
-| highlight(*str*, *type*, *tooltip*) | String    |  | ...with a tooltip popping up on mouse hover
-| iscritical(*roll*)                  | Roll      |  | Return `true` if any die in the roll had its greatest value (e.g. 20 on 1d20), else `false`
-| isfumble(*roll*)                    | Roll      |  | Return `true` if any die in the roll had its smallest value (e.g. 1 on 1d20), else `false`
-| chat(*str*)                         | Chat      | chat("Hi!") | **[Side effect]** Send string *str* to chat
-| getcharid(*name\|id*)                   | Character | getcharid("Finn") | Return the character ID for *name\|id*
-| getattr(*name\|id*, *attr*)             | Character | getattr("Finn", "HP") | Look up attribute *attr* for *name\|id*
-| getattrmax(*name\|id*, *attr*)          | Character | getattrmax("Finn", "HP") | Look up maximum value of attribute *attr* for *name\|id*
-| setattr(*name\|id*, *attr*, *val*)      | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set attribute *attr* for *name\|id* to *val*, then return *val* – create *attr* if necessary
-| setattrmax(*name\|id*, *attr*, *val*)   | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set maximum value of attribute *attr* for *name\|id* to *val* – create *attr* if necessary
+| Syntax                                | Category  | Example | Description
+| ------------------------------------- | --------- | ------- | -----------
+| floor(*a*)                            | Math      | floor(1.7) = 1 | Return the greatest integer that's less than or equal to *a*
+| round(*a*)                            | Math      | round(1.5) = 2 | Round *a* to the nearest integer
+| ceil(*a*)                             | Math      | ceil(1.3) = 2  | Return the smallest integer that's greater than or equal to *a*
+| abs(*a*)                              | Math      | abs(-5) = 5    | Return the absolute value of *a*
+| min(...)                              | Math      | min(3,1,2) = 1 | Return the numerically smallest value – any number of arguments allowed
+| max(...)                              | Math      | max(3,1,2) = 3 | Return the numerically greatest value – any number of arguments allowed
+| len(*str*)                            | String    | len("foo") = 3 | Return the number of character in string *str*
+| literal(*str*)                        | String    | literal("1<2") = "1\&lt;2" | Escape all HTML control characters in string *str*
+| highlight(*str*)                      | String    |  | When output to chat, highlight string *str* with a pretty box
+| highlight(*str*, *type*)              | String    |  | ...with a colored outline depending on *type* = "normal", "important", "good", "bad"
+| highlight(*str*, *type*, *tooltip*)   | String    |  | ...with a tooltip popping up on mouse hover
+| iscritical(*roll*)                    | Roll      |  | Return `true` if any die in the roll had its greatest value (e.g. 20 on 1d20), else `false`
+| isfumble(*roll*)                      | Roll      |  | Return `true` if any die in the roll had its smallest value (e.g. 1 on 1d20), else `false`
+| chat(*str*)                           | Chat      | chat("Hi!") | **[Side effect]** Send string *str* to chat
+| getcharid(*name\|id*)                 | Character | getcharid("Finn") | Return the character ID for *name\|id*
+| getattr(*name\|id*, *attr*)           | Character | getattr("Finn", "HP") | Look up attribute *attr* for *name\|id*
+| getattrmax(*name\|id*, *attr*)        | Character | getattrmax("Finn", "HP") | Look up maximum value of attribute *attr* for *name\|id*
+| setattr(*name\|id*, *attr*, *val*)    | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set attribute *attr* for *name\|id* to *val*, then return *val* – create *attr* if necessary
+| setattrmax(*name\|id*, *attr*, *val*) | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set maximum value of attribute *attr* for *name\|id* to *val* – create *attr* if necessary
 
 
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ If nothing is sent to chat at all after entering this command, MMM isn't install
 
 | Version | Date       | What's new?
 | ------- | ---------- | -----------
+| 1.3.0   | 2021-01-30 | Unify character and token attribute access
 | 1.2.0   | 2021-01-28 | Perform permission checks on attribute queries
 | 1.1.0   | 2021-01-28 | Support `character_id` and `character_name` pseudo-attributes
 | 1.0.0   | 2021-01-26 | Initial release

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ If you want to calculate the square root of something, you can use the power-of 
 | iscritical(*roll*)                  | Roll      |  | Return `true` if any die in the roll had its greatest value (e.g. 20 on 1d20), else `false`
 | isfumble(*roll*)                    | Roll      |  | Return `true` if any die in the roll had its smallest value (e.g. 1 on 1d20), else `false`
 | chat(*str*)                         | Chat      | chat("Hi!") | **[Side effect]** Send string *str* to chat
-| getcharid(*char*)                   | Character | getcharid("Finn") | Return the character ID for *char* – works with both character IDs and full character names
+| getcharid(*name\|id*)                   | Character | getcharid("Finn") | Return the character ID for *name\|id*
 | getattr(*name\|id*, *attr*)             | Character | getattr("Finn", "HP") | Look up attribute *attr* for *name\|id*
 | getattrmax(*name\|id*, *attr*)          | Character | getattrmax("Finn", "HP") | Look up maximum value of attribute *attr* for *name\|id*
 | setattr(*name\|id*, *attr*, *val*)      | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set attribute *attr* for *name\|id* to *val*, then return *val* – create *attr* if necessary

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You're here to yell at dice, not at macros, after all – right?
 ### Contents
 
 - [Scripts](#scripts) – [script commands](#mmm-script--end-script)
-- [Expressions](#expressions) – [literals](#literals), [variables](#variables), [operators](#operators), [functions](#functions)
+- [Expressions](#expressions) – [literals](#literals), [variables](#variables), [attributes](#attributes), [operators](#operators), [functions](#functions)
 - [Frequently Asked Questions](#frequently-asked-questions)
 - [What's new?](#versions)
 - [Copyright & License](#copyright--license)
@@ -264,6 +264,45 @@ There are also a few special *context variables* that are pre-set for you:
 You can *shadow* these special context variables by setting a custom variable with the same name (and your custom variable will then take precedence for the remainder of the script), but you can't truly change them.
 
 
+### Attributes
+
+Like in macros, you can query *attributes* in MMM expressions – and even create and update them if you like:
+
+- Use the `getattr()` and `getattrmax()` functions to query attribute values and max values.
+- Use the `setattr()` and `setattrmax()` functions to update (or, if necessary, create) attributes and max values.
+
+All of these functions take a *name|id* value as their first argument. You can pass a character ID, token ID, character name, or token name. (If you're passing a name and there's ambiguity, MMM always chooses characters over tokens, and if multiple characters should the same name, it'll choose one at random. IDs are always unambiguous.)
+
+If a token represents a specific character (e.g. your character token on the board), it doesn't matter whether you address the token or the character – you'll get access to all attributes of both through either.
+
+MMM has a more general notion of what attributes are than Roll20 itself and adds a few of its own:
+
+| Attribute         | Example              | Value? | Max?  | Description
+| ----------------- | -------------------- | ------ | ----- | -----------
+| `permission`      | `"control"`          | read   | —     | `"none"`, `"view"`, or `"control"` – see below
+| `name`            | `"Finn"`             | read   | —     | Character or token name
+| `token_id`        |                      | read   | —     | Token ID
+| `token_name`      | `"Finn's Spiderbro"` | read   | —     | Token name – provided for Roll20 parity
+| `character_id`    |                      | read   | —     | Character ID
+| `character_name`  | `"Finn"`             | read   | —     | Character name – provided for Roll20 parity
+| `bar1`            | `20` / `30`          | write  | write | Token's top bar value – middle circle (default green)
+| `bar2`            | `20` / `30`          | write  | write | Token's middle bar value – right circle (default blue)
+| `bar3`            | `20` / `30`          | write  | write | Token's bottom bar value – left circle (default red)
+| `left`            | `350` / `1750`       | write  | read  | Token's X coordinate on the table       
+| `top`             | `350` / `1750`       | write  | read  | Token's Y coordinate on the table       
+| *(anything else)* |                      | write  | write | Character attribute – e.g. `HP` or any custom attribute
+
+But keep in mind that just because an attribute *can be accessed* per this table, that doesn't mean *you* can access it.
+
+You can't access anything through MMM you couldn't access manually in the game. For example, you can only read the `left` attribute of a token you can see on the table, or the `HP` attribute of a character you control yourself.
+
+The one exception of this rule is the special `permission` attribute: That one's always there for you to read, even on tokens and characters you're not allowed to access at all or that don't even exist, in which case it'll be `"none"`. Otherwise it can be either `"view"` (you can see aspects of it but not change) or `"control"` (it's yours and you can do anything with it).
+
+Individual attributes may have further restrictions – for example, even if you can see an NPC token, you might not be able to read its `name` unless the GM has made it visible.
+
+If you try to read or write an attribute you don't have permission to, you'll get a special null value back that resolves to zero in numeric context, an empty string in string contaxt, `false` in boolean logic context, and that'll render as the word `denied` on a pretty red background when sent to chat.
+
+
 ### Operators
 
 | Syntax         | Precedence  | Category | Description
@@ -310,10 +349,10 @@ If you want to calculate the square root of something, you can use the power-of 
 | isfumble(*roll*)                    | Roll      |  | Return `true` if any die in the roll had its smallest value (e.g. 1 on 1d20), else `false`
 | chat(*str*)                         | Chat      | chat("Hi!") | **[Side effect]** Send string *str* to chat
 | getcharid(*char*)                   | Character | getcharid("Finn") | Return the character ID for *char* – works with both character IDs and full character names
-| getattr(*char*, *attr*)             | Character | getattr("Finn", "HP") | Look up character attribute *attr* for *char*
-| getattrmax(*char*, *attr*)          | Character | getattrmax("Finn", "HP") | Look up maximum value of character attribute *attr* for *char*
-| setattr(*char*, *attr*, *val*)      | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set character attribute *attr* for *char* to *val*, then return *val* – create *attr* if necessary
-| setattrmax(*char*, *attr*, *val*)   | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set maximum value of character attribute *attr* for *char* to *val* – create *attr* if necessary
+| getattr(*name\|id*, *attr*)             | Character | getattr("Finn", "HP") | Look up attribute *attr* for *name\|id*
+| getattrmax(*name\|id*, *attr*)          | Character | getattrmax("Finn", "HP") | Look up maximum value of attribute *attr* for *name\|id*
+| setattr(*name\|id*, *attr*, *val*)      | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set attribute *attr* for *name\|id* to *val*, then return *val* – create *attr* if necessary
+| setattrmax(*name\|id*, *attr*, *val*)   | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set maximum value of attribute *attr* for *name\|id* to *val* – create *attr* if necessary
 
 
 

--- a/README.md
+++ b/README.md
@@ -332,27 +332,47 @@ If you want to calculate the square root of something, you can use the power-of 
 
 ### Functions
 
-| Syntax                                | Category  | Example | Description
-| ------------------------------------- | --------- | ------- | -----------
-| floor(*a*)                            | Math      | floor(1.7) = 1 | Return the greatest integer that's less than or equal to *a*
-| round(*a*)                            | Math      | round(1.5) = 2 | Round *a* to the nearest integer
-| ceil(*a*)                             | Math      | ceil(1.3) = 2  | Return the smallest integer that's greater than or equal to *a*
-| abs(*a*)                              | Math      | abs(-5) = 5    | Return the absolute value of *a*
-| min(...)                              | Math      | min(3,1,2) = 1 | Return the numerically smallest value – any number of arguments allowed
-| max(...)                              | Math      | max(3,1,2) = 3 | Return the numerically greatest value – any number of arguments allowed
-| len(*str*)                            | String    | len("foo") = 3 | Return the number of character in string *str*
-| literal(*str*)                        | String    | literal("1<2") = "1\&lt;2" | Escape all HTML control characters in string *str*
-| highlight(*str*)                      | String    |  | When output to chat, highlight string *str* with a pretty box
-| highlight(*str*, *type*)              | String    |  | ...with a colored outline depending on *type* = "normal", "important", "good", "bad"
-| highlight(*str*, *type*, *tooltip*)   | String    |  | ...with a tooltip popping up on mouse hover
-| iscritical(*roll*)                    | Roll      |  | Return `true` if any die in the roll had its greatest value (e.g. 20 on 1d20), else `false`
-| isfumble(*roll*)                      | Roll      |  | Return `true` if any die in the roll had its smallest value (e.g. 1 on 1d20), else `false`
-| chat(*str*)                           | Chat      | chat("Hi!") | **[Side effect]** Send string *str* to chat
-| getcharid(*name\|id*)                 | Character | getcharid("Finn") | Return the character ID for *name\|id*
-| getattr(*name\|id*, *attr*)           | Character | getattr("Finn", "HP") | Look up attribute *attr* for *name\|id*
-| getattrmax(*name\|id*, *attr*)        | Character | getattrmax("Finn", "HP") | Look up maximum value of attribute *attr* for *name\|id*
-| setattr(*name\|id*, *attr*, *val*)    | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set attribute *attr* for *name\|id* to *val*, then return *val* – create *attr* if necessary
-| setattrmax(*name\|id*, *attr*, *val*) | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set maximum value of attribute *attr* for *name\|id* to *val* – create *attr* if necessary
+| Syntax                                             | Category  | Example | Description
+| -------------------------------------------------- | --------- | ------- | -----------
+| floor(*a*)                                         | Math      | floor(1.7) = 1 | Return the greatest integer that's less than or equal to *a*
+| round(*a*)                                         | Math      | round(1.5) = 2 | Round *a* to the nearest integer
+| ceil(*a*)                                          | Math      | ceil(1.3) = 2  | Return the smallest integer that's greater than or equal to *a*
+| abs(*a*)                                           | Math      | abs(-5) = 5    | Return the absolute value of *a*
+| min(...)                                           | Math      | min(3,1,2) = 1 | Return the numerically smallest value – any number of arguments allowed
+| max(...)                                           | Math      | max(3,1,2) = 3 | Return the numerically greatest value – any number of arguments allowed
+| len(*str*)                                         | String    | len("foo") = 3 | Return the number of character in string *str*
+| literal(*str*)                                     | String    | literal("1<2") = "1\&lt;2" | Escape all HTML control characters in string *str*
+| highlight(*str*)                                   | String    |  | When output to chat, highlight string *str* with a pretty box
+| highlight(*str*, *type*)                           | String    |  | ...with a colored outline depending on *type* = "normal", "important", "good", "bad"
+| highlight(*str*, *type*, *tooltip*)                | String    |  | ...with a tooltip popping up on mouse hover
+| iscritical(*roll*)                                 | Roll      |  | Return `true` if any die in the roll had its greatest value (e.g. 20 on 1d20), else `false`
+| isfumble(*roll*)                                   | Roll      |  | Return `true` if any die in the roll had its smallest value (e.g. 1 on 1d20), else `false`
+| chat(*str*)                                        | Chat      | chat("Hi!") | **[Side effect]** Send string *str* to chat
+| findattr(*name\|id*)                               | Character | findattr("Finn") | List available character sheet table names – see below
+| findattr(*name\|id*, *table*)                      | Character | findattr("Finn", "attack") | List available columns in a character sheet table – see below
+| findattr(*name\|id*, *table*, *col*, *val*, *col*) | Character | findattr("Finn", "attack", "weapon", "Slingshot", "damage") | Find attribute name in a character sheet table – see below
+| getcharid(*name\|id*)                              | Character | getcharid("Finn") | Return the character ID for *name\|id*
+| getattr(*name\|id*, *attr*)                        | Character | getattr("Finn", "HP") | Look up attribute *attr* for *name\|id*
+| getattrmax(*name\|id*, *attr*)                     | Character | getattrmax("Finn", "HP") | Look up maximum value of attribute *attr* for *name\|id*
+| setattr(*name\|id*, *attr*, *val*)                 | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set attribute *attr* for *name\|id* to *val*, then return *val* – create *attr* if necessary
+| setattrmax(*name\|id*, *attr*, *val*)              | Character | setattr("Finn", "HP", 17) | **[Side effect]** Set maximum value of attribute *attr* for *name\|id* to *val* – create *attr* if necessary
+
+The `findattr()` function helps you determine the attribute name to query (or update) anything that's in an extensible table in a character sheet.
+
+These attribute names always start with `repeating_`... followed by a table name (e.g. `attack`), followed by a soup of random characters (the row ID), and finally the name of column you're interested in (e.g. `damage`). Official [Roll20 guidance](https://help.roll20.net/hc/en-us/articles/360037256794-Macros#Macros-ReferencingRepeatingAttributes) says to break out your HTML debugger and dive into the character sheet's HTML source to figure out these IDs – but that's a hair-on-fire–tier harebrained way to have to go about this.
+
+With `findattr()` you can do all this without leaving the safe comfort of your chat box:
+
+| Line | Commands | What happens?
+| ---- | -------- | -------------
+| 1    | _!mmm_ **chat:** Tables: ${findattr(sender)} | ***Finn:*** Tables: attack, defense, armor
+| 2    | _!mmm_ **chat:** Columns: ${findattr(sender, "attack")} | ***Finn:*** Columns: weapon, skill, damage
+| 3    | _!mmm_ **chat:** Attribute: ${findattr(sender, "attack", "weapon", "Slingshot", "damage")} | ***Finn:*** Attribute: repeating_attack_-MSxAHDgxtzAHdDAIopE_damage
+| 4    | _!mmm_ **chat:** Value: ${getattr(sender, findattr(sender, "attack", "weapon", "Slingshot", "damage"))} | ***Finn:*** Value: 1d6
+
+What's happening in the last two lines above is that you're *selecting* one of the rows based on a condition: in this case, you want to get to the `damage` attribute of the `attack` table row that has the value `Slingshot` in its `weapon` column – so, the damage dealt by your slingshot. You can include several pairs of *column*, *value* to narrow down your selection if necessary.
+
+Unlike most other things in MMM, table names, column names, and column values are case-insensitive in the `findattr()` function.
 
 
 


### PR DESCRIPTION
- Unify access to token and character attributes (especially for tokens representing a character)
- Add support for token quasi-attributes including `bar1`...`bar3`, `left`, and `top`
- Introduce `findattr()` utility function
- Improve attribute access permission checks and highlight denied attribute values in chat output

Version: 1.3.0
Resolves: #5 #3 #8