### PR TITLE
defense.mmm: Added visual fx for various hits via spawnfx()

### DIFF
--- a/examples/midgard/defense/README.md
+++ b/examples/midgard/defense/README.md
@@ -1,6 +1,6 @@
 # MMM-Abwehrskript für Midgard (5. Ausgabe)
 
-Aktuelle Version: **1.2.1 vom 2021-04-14,** erfordert MMM 1.16.0+, ist in unserem Midgard-Spiel installiert (`#defend`).
+Aktuelle Version: **1.3.0 vom 2021-04-18,** erfordert MMM 1.17.0+.
 
 Das MMM-basierte Midgard-Abwehrskript führt die Abwehr von Angriffen durch. Dabei werden die eigene Erschöpfung (-4 bei AP:0) und die eingestellte Rüstung automatisch und weitere Modifikatoren nach Benutzerauswahl und -eingabe berücksichtigt, und die Konsequenzen umgesetzt (Abzüge AP und LP, ggf. Ausgabe der Folgen). Optional lassen sich in einem kurzen Konfigurationsskript die Auswahl der Abwehrwaffe (Schild/Parierwaffe) und die Textausgaben anpassen.
 
@@ -71,6 +71,10 @@ Beispiel für einen Parierdolch, ohne die Erzählerei zu verändern (Voraussetzu
 ```
 
 ## Changelog
+
+1.3.0 2021-04-18
+
+- Visuelle Effekte für leichte, schwere und kritische Treffer ergänzt (erfordert MMM 1.17.0)
 
 1.2.1 2021-04-14
 

--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
-!rem // v1.2.1 2021-04-14
+!rem // v1.3.0 2021-04-18
 !rem // 
-!rem // - #2: Elegantere Integration des Animierten Würfels für den Abwehrwurf 
+!rem // - Visuelle Effekte für leichte, schwere und kritische Treffer ergänzt (MMM 1.17.0)
 !rem
 !mmm script
 !mmm
@@ -238,12 +238,15 @@
 !mmm     else if attackDamage > 0 and defenseSuccess
 !mmm       chat: {{Erfolg=**Leichter Treffer**}}
 !mmm       chat: {{Schaden=**${effEnduranceLoss}&nbsp;AP**}}
+!mmm       do spawnfx("bubbling-water", getattr(cOwnID, "left"), getattr(cOwnID, "top"))
 !mmm     else if attackDamage > 0 and (not defenseSuccess) and criticalAttack
 !mmm       chat: {{Fehlschlag=**Schwerer kritischer Treffer**}}
 !mmm       chat: {{Schaden=**${effHealthLoss}&nbsp;LP&nbsp;/&nbsp;${effEnduranceLoss}&nbsp;AP +&nbsp;krit.&nbsp;Schaden!**}}
+!mmm       do spawnfx("nova-blood", getattr(cOwnID, "left"), getattr(cOwnID, "top"))
 !mmm     else 
 !mmm       chat: {{Fehlschlag=**Schwerer Treffer**}}
 !mmm       chat: {{Schaden=**${effHealthLoss}&nbsp;LP&nbsp;/&nbsp;${effEnduranceLoss}&nbsp;AP**}}
+!mmm       do spawnfx("bubbling-blood", getattr(cOwnID, "left"), getattr(cOwnID, "top"))
 !mmm     end if
 !mmm     if newHealth < 0 and timeToDie < 0
 !mmm       chat: {{Zustand=**Sofortiger Tod &#10013;**}}


### PR DESCRIPTION
Some new eye candy for key results of the defense roll, making use of the brand-new `spawnfx()` function in MMM 1.17, once it exists (so we might want to keep this PR open until MMM 1.17 has landed?). 

Resolves [MGD#4](https://github.com/phylll/mychs-macro-magic/issues/4) for the defense script.