### PR TITLE
`sense`: solved MGD#8, special night vision modifiers

### DIFF
--- a/examples/midgard/sense/senseConfig.mmm
+++ b/examples/midgard/sense/senseConfig.mmm
@@ -186,7 +186,7 @@
 !mmm customize
 !rem
 !mmm   set cSense = "Nachtsicht"
-!mmm   set cSenseModifier = ?{Die ausgewählten sind... | normal unterwegs (-8),-8 | absolut wachsam (-0),0 | Manuelle Eingabe,?{Modifikator&#124;&#125; }
+!mmm   set cSenseModifier = ?{Es ist... | stockdunkel (-8/-6),-6 | bewölkt+Neumond (-6/-4),-4 | wolkenlos+Neumond/bewölkt+Halbmond (-5/-3),-3 | wolkenlos+Halbmond/bewölkt+Vollmond (-4/-2),-2 | wolkenlos+Vollmond (-2/-0),0 | Manuelle Eingabe,?{Modifikator&#124;-8&#125; }
 !mmm   set cSuccessMessage = "?{Seht ihr was? Nachricht für Aufmerksame|Da hinten! Ein unnatürlicher Schatten?}"
 !mmm   set cRegularFailureMessage = "Deinen Augen fällt nichts besonderes auf hier."
 !mmm   set cCriticalFailureMessage = "?{Nachricht bei Patzern|Deinen Augen fällt nichts besonderes auf hier.}"
@@ -199,7 +199,7 @@
 !mmm customize
 !rem
 !mmm   set cSense = "Nachtsicht"
-!mmm   set cSenseModifier = -8
+!mmm   set cSenseModifier = ?{Es ist... | stockdunkel (-8/-6),-6 | bewölkt+Neumond (-6/-4),-4 | wolkenlos+Neumond/bewölkt+Halbmond (-5/-3),-3 | wolkenlos+Halbmond/bewölkt+Vollmond (-4/-2),-2 | wolkenlos+Vollmond (-2/-0),0 | Manuelle Eingabe,?{Modifikator&#124;-8&#125; }
 !mmm   set cSuccessMessage = "?{Seht ihr was? Nachricht für Aufmerksame|Da hinten! Ein unnatürlicher Schatten?}"
 !mmm   set cRegularFailureMessage = "Deinen Augen fällt nichts besonderes auf hier."
 !mmm   set cCriticalFailureMessage = "Deinen Augen fällt nichts besonderes auf hier."

--- a/examples/midgard/sense/senseLogic.mmm
+++ b/examples/midgard/sense/senseLogic.mmm
@@ -1,5 +1,5 @@
 !rem // Midgard Multi-Sense Script 
-!rem // v1.1.0 2021-05-18
+!rem // v1.1.1 2021-05-22
 !rem //
 !rem // senseMainLogic -- must be called from a config script
 !rem //
@@ -33,10 +33,6 @@
 !mmm     set cTokenList = selected
 !mmm   end if
 !mmm
-!rem   // cSenseModifier: if positive, add sign for later output
-!mmm   if cSenseModifier > 0
-!mmm     set cSenseModifier = "+" & cSenseModifier
-!mmm   end if
 !rem   // Output formatting constants
 !mmm   set playerMsgEmoji = "💬"
 !mmm   set cssGMTableHead = "#\" style=\"border: 1px solid #000000; display:block;background-color:#702082;margin:0px;padding:5px;font-size:1.05em;font-style:normal;font-weight:bold;color:#FFFFFF;text-decoration:none;"
@@ -45,7 +41,7 @@
 !mmm   set cssGMTableItemSuccess = "#\" style=\"border-left: 1px solid #000000;border-right: 1px solid #000000;border-bottom: 1px solid #000000; display:block;background-color:#60f086;margin:0px;padding:5px;font-style:normal;color:#000000;text-decoration:none;"
 !mmm   set cssGMTableItemCriticalFailure = "#\" style=\"border-left: 1px solid #000000;border-right: 1px solid #000000;border-bottom: 1px solid #000000; display:block;background-color:#f06560;margin:0px;padding:5px;font-style:normal;color:#000000;text-decoration:none;"
 !rem
-!rem   // Due diligence: weed out duplicates, in case cTokenList was populated manually or via {target}
+!rem   // Due diligence: weed out duplicate tokens, in case cTokenList was populated manually or via {target}
 !mmm   for id in cTokenList
 !mmm     set dupeFound = false
 !mmm     for trimmedId in trimmedTokenList
@@ -68,9 +64,11 @@
 !mmm       set tokenId = getattr(id, "token_id")
 !mmm       set charName = getattr(tokenId, "character_name")
 !mmm       set charEffectiveSkill = getattr(tokenId, findattr(tokenId, "sinne", "Fertigkeit2", cSense, "FW2")) + getattr(tokenId, findattr(tokenId, "sinne", "Fertigkeit2", cSense, "Fertigkeitsbonus2"))
+!mmm       set charSenseModifier = cSenseModifier
 !mmm       if cSense eq "Nachtsicht" and not charEffectiveSkill
-!rem         // For characters without night vision, substitute Vision without a bonus
+!rem         // For characters without night vision, substitute Vision without a bonus & slap -2 on the modifier
 !mmm         set charEffectiveSkill = getattr(tokenId, findattr(tokenId, "sinne", "Fertigkeit2", "Sehen", "FW2"))
+!mmm         set charSenseModifier = charSenseModifier - 2
 !mmm       end if
 !mmm
 !rem       // Error handling
@@ -81,13 +79,16 @@
 !rem       // And if everything is ready...
 !mmm       else
 !rem         // Execute sense rolls 
-!mmm         set effModifier = charEffectiveSkill + cSenseModifier
-!mmm         if effModifier > 0 
+!mmm         set effModifier = charEffectiveSkill + charSenseModifier
+!mmm         if effModifier >= 0 
 !mmm           set effModifier = "+" & effModifier
 !mmm         end if
 !mmm         set senseRoll = roll("1d20" & effModifier)
 !rem         // Overwrite tooltip to break down components
-!mmm         set senseResultTooltip = senseRoll & " = (1d20 = " & (senseRoll - effModifier) & ") + (EW = " & charEffectiveSkill & ") " & cSenseModifier
+!mmm         if charSenseModifier >= 0
+!mmm           set charSenseModifier = "+" & charSenseModifier
+!mmm         end if
+!mmm         set senseResultTooltip = senseRoll & " = (1d20 = " & (senseRoll - effModifier) & ") + (EW = " & charEffectiveSkill & ") " & charSenseModifier
 !mmm         set senseResult = highlight(senseRoll, default, senseResultTooltip)
 !mmm         
 !rem         // Compose output table row for GM


### PR DESCRIPTION
Solved [MGD#8](https://github.com/phylll/mychs-macro-magic/issues/8), adding a night vision modifier dropdown to config scripts and the extra -2 for non-night-vision-capable characters to the logic. 

Also stumbled upon and fixed a bug where non-zero modifiers that add up to 0 (such as, -2+2=0) produced a massively inflated roll formula ("1d20" & 0 = "1d200"). Changed to "1d20" & "+0" = "1d20+0".