### PR TITLE
Introduce `list[idx]` and `obj.prop` expression syntax

### DIFF
--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -4389,7 +4389,7 @@ class MychExpression
 
         if (!this.evaluator.isConstant)
         {
-            throw new MychExpressionError("evaluate", "no expression parsed prior to evaluation", "", 0);
+            throw new MychExpressionError("evaluate", "expression is not parse-time constant", this.source, 0);
         }
 
         let resultContainer = this.evaluator(undefined).next();

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -3016,7 +3016,13 @@ class MychTemplate
             else if (segmentMatch.groups.escape)
             {
                 let string = segmentMatch.groups.escape;
-                let stringSegment = { type: "string", value: string, source: segmentMatch[0] };
+
+                let stringSegment =
+                {
+                    type: "string",
+                    value: string,
+                    source: segmentMatch[0],
+                };
 
                 this.segments.push(stringSegment);
             }

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -2964,7 +2964,7 @@ class MychTemplate
             return "(" + (pattern instanceof RegExp ? pattern.source : pattern) + ")";
         }
 
-        return new RegExp(segmentPatterns.map(createSegmentRegExpSource).join("|"), "gd");
+        return new RegExp(segmentPatterns.map(createSegmentRegExpSource).join("|"), "g");
     }
 
     parse(source, context)
@@ -3023,7 +3023,7 @@ class MychTemplate
             else if (segmentMatch.groups.expression)
             {
                 let expressionLabel = segmentMatch.groups.label;
-                let expressionOffset = segmentMatch.indices.groups.expression[0];
+                let expressionOffset = segmentMatch.index + "$".length + (segmentMatch.groups.labelToken ? segmentMatch.groups.labelToken.length : 0) + "{".length;
 
                 try
                 {
@@ -3064,7 +3064,7 @@ class MychTemplate
                 this.segments.push(referenceSegment);
             }
 
-            segmentOffset = segmentMatch.indices[0][1];
+            segmentOffset = segmentMatch.index + segmentMatch[0].length;
         }
 
         if (segmentOffset < source.length)

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -1,7 +1,7 @@
 // Mych's Macro Magic by Michael Buschbeck <michael@buschbeck.net> (2021)
 // https://github.com/michael-buschbeck/mychs-macro-magic/blob/main/LICENSE
 
-const MMM_VERSION = "1.19.1";
+const MMM_VERSION = "1.20.0";
 
 on("chat:message", function(msg)
 {
@@ -721,6 +721,19 @@ class MychScriptContext
     {
         log(exception.stack);
         this.whisperback(this.literal(exception));
+    }
+
+    getprop(nameOrId, attributeName)
+    {
+        let attributeValue = this.getattr(nameOrId, attributeName);
+
+        let attributeStruct =
+        {
+            toScalar: () => attributeValue,
+            getProperty: key => (key == "max") ? this.getattrmax(nameOrId, attributeName) : this.getprop(attributeValue, key),
+        };
+
+        return attributeStruct;
     }
 
     distunits()
@@ -1901,7 +1914,7 @@ class MychScript
                     try
                     {
                         this.definition.expressionOffset = args.expression.offset;
-                        this.definition.expression = new MychExpression(args.expression.value);
+                        this.definition.expression = new MychExpression(args.expression.value, this.context);
                     }
                     catch (exception)
                     {
@@ -1920,7 +1933,7 @@ class MychScript
 
                     try
                     {
-                        exitCondition = yield* this.definition.expression.evaluate(variables, this.context);
+                        exitCondition = yield* this.definition.expression.evaluate(variables);
                     }
                     catch (exception)
                     {
@@ -1951,7 +1964,7 @@ class MychScript
                 try
                 {
                     this.definition.expressionOffset = args.expression.offset;
-                    this.definition.expression = new MychExpression(args.expression.value);
+                    this.definition.expression = new MychExpression(args.expression.value, this.context);
                 }
                 catch (exception)
                 {
@@ -1972,7 +1985,7 @@ class MychScript
 
                     try
                     {
-                        branchCondition = yield* branchScript.definition.expression.evaluate(variables, this.context);
+                        branchCondition = yield* branchScript.definition.expression.evaluate(variables);
                     }
                     catch (exception)
                     {
@@ -2020,7 +2033,7 @@ class MychScript
                     try
                     {
                         this.definition.expressionOffset = args.expression.offset;
-                        this.definition.expression = new MychExpression(args.expression.value);
+                        this.definition.expression = new MychExpression(args.expression.value, this.context);
                     }
                     catch (exception)
                     {
@@ -2054,7 +2067,7 @@ class MychScript
                 try
                 {
                     this.definition.expressionOffset = args.expression.offset;
-                    this.definition.expression = new MychExpression(args.expression.value);
+                    this.definition.expression = new MychExpression(args.expression.value, this.context);
                 }
                 catch (exception)
                 {
@@ -2068,7 +2081,7 @@ class MychScript
 
                 try
                 {
-                    collection = yield* this.definition.expression.evaluate(variables, this.context);
+                    collection = yield* this.definition.expression.evaluate(variables);
                 }
                 catch (exception)
                 {
@@ -2113,7 +2126,7 @@ class MychScript
                     try
                     {
                         this.definition.expressionOffset = args.expression.offset;
-                        this.definition.expression = new MychExpression(args.expression.value);
+                        this.definition.expression = new MychExpression(args.expression.value, this.context);
                     }
                     catch (exception)
                     {
@@ -2147,7 +2160,7 @@ class MychScript
 
                 try
                 {
-                    variables[this.definition.variable] = yield* this.definition.expression.evaluate(variables, this.context);
+                    variables[this.definition.variable] = yield* this.definition.expression.evaluate(variables);
                 }
                 catch (exception)
                 {
@@ -2172,10 +2185,10 @@ class MychScript
                 }
                 else if (this.definition.expression)
                 {
-                    if (this.definition.expression.tokens.length == 1 && this.definition.expression.tokens[0].type == "literal")
+                    if (this.definition.expression.isConstant())
                     {
-                        let onlyExpressionToken = this.definition.expression.tokens[0];
-                        customizationCommand += " = " + MychExpression.literal(onlyExpressionToken.value);
+                        let constantExpressionResult = this.definition.expression.evaluateConstant();
+                        customizationCommand += " = " + MychExpression.literal(constantExpressionResult);
                     }
                     else
                     {
@@ -2202,7 +2215,7 @@ class MychScript
                 try
                 {
                     this.definition.expressionOffset = args.expression.offset;
-                    this.definition.expression = new MychExpression(args.expression.value);
+                    this.definition.expression = new MychExpression(args.expression.value, this.context);
                 }
                 catch (exception)
                 {
@@ -2216,7 +2229,7 @@ class MychScript
             {
                 try
                 {
-                    yield* this.definition.expression.evaluate(variables, this.context);
+                    yield* this.definition.expression.evaluate(variables);
                 }
                 catch (exception)
                 {
@@ -2241,7 +2254,7 @@ class MychScript
                     try
                     {
                         this.definition.templateOffset = args.template.offset;
-                        this.definition.template = new MychTemplate(args.template.value);
+                        this.definition.template = new MychTemplate(args.template.value, this.context);
                     }
                     catch (exception)
                     {
@@ -2268,7 +2281,7 @@ class MychScript
 
                     try
                     {
-                        message = yield* evaluateTemplate.evaluate(variables, this.context);
+                        message = yield* evaluateTemplate.evaluate(variables);
                     }
                     catch (exception)
                     {
@@ -2316,7 +2329,7 @@ class MychScript
                     try
                     {
                         this.definition.expressionOffset = args.expression.offset;
-                        this.definition.expression = new MychExpression(args.expression.value);
+                        this.definition.expression = new MychExpression(args.expression.value, this.context);
                     }
                     catch (exception)
                     {
@@ -2333,7 +2346,7 @@ class MychScript
                 {
                     try
                     {
-                        separator = yield* this.definition.expression.evaluate(variables, this.context);
+                        separator = yield* this.definition.expression.evaluate(variables);
                     }
                     catch (exception)
                     {
@@ -2508,7 +2521,7 @@ class MychScript
                 try
                 {
                     this.definition.templateOffset = args.template.offset;
-                    this.definition.template = new MychTemplate(args.template.value);
+                    this.definition.template = new MychTemplate(args.template.value, this.context);
                 }
                 catch (exception)
                 {
@@ -2524,7 +2537,7 @@ class MychScript
 
                 try
                 {
-                    translation = yield* this.definition.template.createMaterialized(variables, this.context);
+                    translation = yield* this.definition.template.createMaterialized(variables);
                 }
                 catch (exception)
                 {
@@ -2552,7 +2565,7 @@ class MychScript
                     try
                     {
                         this.definition.templateOffset = args.template.offset;
-                        this.definition.template = new MychTemplate(args.template.value);
+                        this.definition.template = new MychTemplate(args.template.value, this.context);
                     }
                     catch (exception)
                     {
@@ -2570,7 +2583,7 @@ class MychScript
                     try
                     {
                         this.definition.expressionOffset = args.expression.offset;
-                        this.definition.expression = new MychExpression(args.expression.value);
+                        this.definition.expression = new MychExpression(args.expression.value, this.context);
                     }
                     catch (exception)
                     {
@@ -2589,7 +2602,7 @@ class MychScript
 
                     try
                     {
-                        message = yield* this.definition.template.evaluate(variables, this.context, value => this.context.$debugExpression(value));
+                        message = yield* this.definition.template.evaluate(variables, value => this.context.$debugExpression(value));
                     }
                     catch (exception)
                     {
@@ -2605,7 +2618,7 @@ class MychScript
 
                     try
                     {
-                        result = yield* this.definition.expression.evaluate(variables, this.context);
+                        result = yield* this.definition.expression.evaluate(variables);
                     }
                     catch (exception)
                     {
@@ -2901,15 +2914,16 @@ class MychTemplateError
 
 class MychTemplate
 {
-    constructor(source)
+    constructor(source, context)
     {
         this.source = undefined;
+        this.context = undefined;
         this.segments = [];
         this.expressionSegments = {};
 
         if (source != undefined)
         {
-            this.parse(source);
+            this.parse(source, context);
         }
     }
 
@@ -2923,155 +2937,169 @@ class MychTemplate
         throw new MychTemplateError(stage, exception + " in expression", this.source, expressionOffset, exception);
     }
 
-    parse(source)
+    static createSegmentRegExp(context)
     {
-        let segments = [];
-        let segmentRegExp = /(?<string>([^\\$]|\\.|\$(?!\{|\[\w))+)|\$(\[(?<exlabel>\w+)\])?\{(?<expression>([^}"']|"([^\\"]|\\.)*"|'([^\\']|\\.)*')*)\}|\$\[(?<reflabel>\w+)\]/g;
+        let segmentPatterns =
+        [   
+            /\\(?<escape>.)/,
+            /\$(?=(?<labelToken>\[(?<label>\w+)\])?(?<expressionToken>\{(?<expression>([^"'}]|"([^\\"]|\\.)*"|'([^\\']|\\.)*')*)\})?)(\k<labelToken>\k<expressionToken>|\k<labelToken>|\k<expressionToken>)/,
+        ];
+
+        let contextKeys = Object.keys(context).filter(key => /^(\W|\W.*\W)$/.test(key));
+
+        if (contextKeys.length > 0)
+        {
+            function createContextKeyRegExpSource(key)
+            {
+                // escape all characters that might have special meaning and add boundary assertions
+                return key.replace(/(\W)/g, "\\$1").replace(/^\b|\b$/g, "\\b");
+            }
+    
+            let contextKeysRegExpSources = contextKeys.map(createContextKeyRegExpSource);
+            segmentPatterns.unshift("(?<context>" + contextKeysRegExpSources.join("|") + ")");
+        }
+
+        function createSegmentRegExpSource(pattern)
+        {
+            return "(" + (pattern instanceof RegExp ? pattern.source : pattern) + ")";
+        }
+
+        return new RegExp(segmentPatterns.map(createSegmentRegExpSource).join("|"), "gd");
+    }
+
+    parse(source, context)
+    {
+        if (context == undefined)
+        {
+            throw "MychTemplate internal error: no parse context";
+        }
+
+        this.source = source;
+        this.context = context;
+        this.segments = [];
+
+        let segmentRegExp = MychTemplate.createSegmentRegExp(context);
         let segmentMatch;
 
         let segmentOffset = 0;
 
         while (segmentMatch = segmentRegExp.exec(source))
         {
-            if (segmentMatch.index != segmentOffset)
+            if (segmentOffset < segmentMatch.index)
             {
-                throw new MychTemplateError("parse", "syntax error", source, segmentOffset);
+                let stringValue = source.substring(segmentOffset, segmentMatch.index);
+                
+                let stringSegment =
+                {
+                    type: "string",
+                    value: stringValue,
+                    source: stringValue,
+                };
+
+                this.segments.push(stringSegment);
             }
 
-            if (segmentMatch.groups.string)
+            if (segmentMatch.groups.context)
             {
-                let string = segmentMatch.groups.string.replace(/\\(.)/g, "$1");
-                let stringSegment = { type: "string", value: string };
+                let contextKey = segmentMatch.groups.context;
+                let contextValue = context[contextKey];
 
-                segments.push(stringSegment);
+                let contextSegment =
+                {
+                    type: "context",
+                    value: contextValue,
+                    source: segmentMatch[0],
+                };
+
+                this.segments.push(contextSegment);
             }
-
-            if (segmentMatch.groups.expression)
+            else if (segmentMatch.groups.escape)
             {
-                let expressionLabel = segmentMatch.groups.exlabel;
-                let expressionOffset = segmentOffset + "${".length + (expressionLabel ? ("[]".length + expressionLabel.length) : 0);
+                let string = segmentMatch.groups.escape;
+                let stringSegment = { type: "string", value: string, source: segmentMatch[0] };
+
+                this.segments.push(stringSegment);
+            }
+            else if (segmentMatch.groups.expression)
+            {
+                let expressionLabel = segmentMatch.groups.label;
+                let expressionOffset = segmentMatch.indices.groups.expression[0];
 
                 try
                 {
-                    let expression = new MychExpression(segmentMatch.groups.expression);
-                    let expressionSegment = { type: "expression", offset: expressionOffset, expression: expression, label: expressionLabel };
+                    let expression = new MychExpression(segmentMatch.groups.expression, context);
+
+                    let expressionSegment =
+                    {
+                        type: "expression",
+                        offset: expressionOffset,
+                        expression: expression,
+                        label: expressionLabel,
+                        source: segmentMatch[0],
+                    };
 
                     if (expressionLabel)
                     {
                         this.expressionSegments[expressionLabel] = expressionSegment;
                     }
 
-                    segments.push(expressionSegment);
+                    this.segments.push(expressionSegment);
                 }
                 catch (exception)
                 {
                     this.rethrowExpressionError("parse", exception, expressionOffset);
                 }
             }
-            
-            if (segmentMatch.groups.reflabel)
+            else if (segmentMatch.groups.label)
             {
-                let referenceLabel = segmentMatch.groups.reflabel;
-                let referenceSegment = { type: "reference", label: referenceLabel };
+                let referenceLabel = segmentMatch.groups.label;
                 
-                segments.push(referenceSegment);
+                let referenceSegment =
+                {
+                    type: "reference",
+                    label: referenceLabel,
+                    source: segmentMatch[0],
+                };
+                
+                this.segments.push(referenceSegment);
             }
 
-            segmentOffset = segmentMatch.index + segmentMatch[0].length;
+            segmentOffset = segmentMatch.indices[0][1];
         }
 
-        if (segmentOffset != source.length)
+        if (segmentOffset < source.length)
         {
-            throw new MychTemplateError("parse", "syntax error", source, segmentOffset);
-        }
+            let stringValue = source.substring(segmentOffset);
 
-        this.segments = segments;
+            let stringSegment =
+            {
+                type: "string",
+                value: stringValue,
+                source: stringValue,
+            };
+
+            this.segments.push(stringSegment);
+        }
     }
 
     getSourceWithReferences()
     {
         function reconstructSegment(segment)
         {
-            if (segment.type == "string")
+            if (segment.type == "expression")
             {
-                return segment.value.replace(/(\$[\{\[]|\\)/, "\\\\$1");
+                return segment.label ? ("$[" + segment.label + "]") : "...";
             }
-
-            if (segment.type == "expression" && segment.label)
-            {
-                return "$[" + segment.label + "]";
-            }
-
-            return "...";
+            
+            return segment.source;
         }
 
         return this.segments.map(reconstructSegment).join("");
     }
 
-    static createContextKeysRegExp(context)
-    {
-        let contextKeys = Object.keys(context).filter(key => /^(\W|\W.*\W)$/.test(key));
-
-        if (contextKeys.length == 0)
-        {
-            return undefined;
-        }
-
-        return new RegExp(contextKeys.map(key => key.replace(/(\W)/g, "\\$1").replace(/^\b|\b$/, "\\b")).join("|"), "g");
-    }
-
-    static evaluateContextKeys(string, contextKeysRegExp, context, convertExpression = value => value)
-    {
-        if (!contextKeysRegExp || !contextKeysRegExp.test(string))
-        {
-            return string;
-        }
-
-        let evaluatedSegments = [];
-
-        let contextKeysMatch;
-        let stringBegin = 0;
-
-        contextKeysRegExp.lastIndex = 0;
-
-        while (contextKeysMatch = contextKeysRegExp.exec(string))
-        {
-            if (stringBegin < contextKeysMatch.index)
-            {
-                let stringEnd = contextKeysMatch.index;
-                evaluatedSegments.push(string.substring(stringBegin, stringEnd))
-            }
-
-            let contextKey = contextKeysMatch[0];
-            evaluatedSegments.push(convertExpression(context[contextKey]));
-
-            stringBegin = contextKeysRegExp.lastIndex;
-        }
-
-        if (stringBegin < string.length)
-        {
-            evaluatedSegments.push(string.substring(stringBegin));
-        }
-
-        if (evaluatedSegments.length <= 1)
-        {
-            return evaluatedSegments[0];
-        }
-
-        let combinedEvaluatedSegments =
-        {
-            toScalar: () => evaluatedSegments.map(MychExpression.coerceString).join(""),
-            toMarkup: () => evaluatedSegments.map(MychExpression.coerceMarkup).join(""),
-        };
-
-        return combinedEvaluatedSegments;
-    }
-
-    *evaluate(variables, context, convertExpression = value => value)
+    *evaluate(variables, convertExpression = value => value)
     {
         let evaluatedSegments = [];
-
-        let contextKeysRegExp = MychTemplate.createContextKeysRegExp(context);
 
         for (let segment of this.segments)
         {
@@ -3079,8 +3107,15 @@ class MychTemplate
             {
                 case "string":
                 {
-                    let evaluatedString = MychTemplate.evaluateContextKeys(segment.value, contextKeysRegExp, context, convertExpression);
+                    let evaluatedString = segment.value;
                     evaluatedSegments.push(evaluatedString);
+                }
+                break;
+
+                case "context":
+                {
+                    let evaluatedContext = segment.value;
+                    evaluatedSegments.push(evaluatedContext);
                 }
                 break;
 
@@ -3088,7 +3123,7 @@ class MychTemplate
                 {
                     try
                     {
-                        let evaluatedExpressionResult = yield* segment.expression.evaluate(variables, context);
+                        let evaluatedExpressionResult = yield* segment.expression.evaluate(variables);
                         evaluatedSegments.push(convertExpression(evaluatedExpressionResult));
                     }
                     catch (exception)
@@ -3126,20 +3161,20 @@ class MychTemplate
         let translatedTemplate = new MychTemplate();
 
         translatedTemplate.source = this.source;
+        translatedTemplate.context = this.context;
         translatedTemplate.expressionSegments = this.expressionSegments;
         translatedTemplate.segments = translationTemplate.segments.map(segment => (segment.type == "reference" ? this.expressionSegments[segment.label] : undefined) || segment);
 
         return translatedTemplate;
     }
 
-    *createMaterialized(variables, context, convertExpression = value => value)
+    *createMaterialized(variables, convertExpression = value => value)
     {
         let materializedTemplate = new MychTemplate();
 
         materializedTemplate.source = this.source;
+        materializedTemplate.context = this.context;
         materializedTemplate.expressionSegments = {};
-
-        let contextKeysRegExp = MychTemplate.createContextKeysRegExp(context);
 
         for (let segment of this.segments)
         {
@@ -3147,10 +3182,22 @@ class MychTemplate
             {
                 case "string":
                 {
-                    let materializedString = MychExpression.coerceString(MychTemplate.evaluateContextKeys(segment.value, contextKeysRegExp, context, convertExpression));
-                    let materializedStringSegment = { type: "string", value: materializedString };
+                    let materializedString = segment.value;
+
+                    let materializedStringSegment =
+                    {
+                        type: "string",
+                        value: materializedString,
+                        source: materializedString,
+                    };
 
                     materializedTemplate.segments.push(materializedStringSegment);
+                }
+                break;
+
+                case "context":
+                {
+                    materializedTemplate.segments.push(segment);
                 }
                 break;
 
@@ -3158,8 +3205,15 @@ class MychTemplate
                 {
                     try
                     {
-                        let materializedExpressionResult = yield* segment.expression.evaluate(variables, context);
-                        let materializedExpressionSegment = { type: "string", value: convertExpression(materializedExpressionResult) };
+                        let materializedExpressionResult = yield* segment.expression.evaluate(variables);
+                        let materializedExpressionString = convertExpression(materializedExpressionResult);
+
+                        let materializedExpressionSegment =
+                        {
+                            type: "string",
+                            value: materializedExpressionString,
+                            source: materializedExpressionString,
+                        };
 
                         materializedTemplate.segments.push(materializedExpressionSegment);
                     }
@@ -3206,14 +3260,16 @@ class MychExpressionArgs extends Array
 
 class MychExpression
 {
-    constructor(source)
+    constructor(source, context)
     {
         this.source = undefined;
+        this.context = context;
         this.tokens = [];
+        this.evaluator = undefined;
     
         if (source != undefined)
         {
-            this.parse(source);
+            this.parse(source, context);
         }
     }
 
@@ -3237,6 +3293,11 @@ class MychExpression
         if (value && value.toMarkup instanceof Function)
         {
             return value.toMarkup();
+        }
+
+        if (value && value.toScalar instanceof Function)
+        {
+            return MychExpression.coerceMarkup(value.toScalar());
         }
 
         return MychExpression.coerceString(value);
@@ -3371,110 +3432,692 @@ class MychExpression
         return String(value);
     }
 
-    static operators =
+    static rules =
     {
-        "**": {
-            binary: { precedence: 1, execute: (a,b) => MychExpression.coerceNumber(a) ** MychExpression.coerceNumber(b), associativity: "right" }
+        unaryOperator:
+        {
+            description: "unary operator",
+            tokenType: [ "unaryOperator", "unaryOrBinaryOperator" ],
+
+            processToken: function(token, state, context)
+            {
+                let operatorDef = MychExpression.unaryOperatorDefs[token.value];
+
+                let coerceValue = operatorDef.coerceValue || (value => value);
+
+                function unaryOperator(evaluator)
+                {
+                    return function* unaryOperatorEvaluator(variables)
+                    {
+                        let value = coerceValue(yield* evaluator(variables));
+                        return operatorDef.evaluate(value);
+                    }
+                }
+
+                state.pushOperator(token, unaryOperator, operatorDef.precedence, { isIdempotent: true });
+            },
+
+            nextRuleNames: new Set(
+            [
+                "unaryOperator",
+                "debugOperator",
+                "literal",
+                "symbolLookup",
+                "openingParenthesis",
+            ]), 
         },
-        "*": {
-            binary: { precedence: 3, execute: (a,b) => MychExpression.coerceNumber(a) * MychExpression.coerceNumber(b) }
+        binaryOperator:
+        {
+            description: "binary operator",
+            tokenType: [ "binaryOperator", "unaryOrBinaryOperator" ],
+
+            processToken: function(token, state, context)
+            {
+                let operatorDef = MychExpression.binaryOperatorDefs[token.value];
+
+                let coerceValueA = operatorDef.coerceValueA || (value => value);
+                let coerceValueB = operatorDef.coerceValueB || (value => value);
+
+                function binaryOperator(evaluatorA, evaluatorB)
+                {
+                    return function* binaryOperatorEvaluator(variables)
+                    {
+                        let valueA = coerceValueA(yield* evaluatorA(variables));
+                        let valueB = coerceValueB(yield* evaluatorB(variables));
+                        return operatorDef.evaluate(valueA, valueB);
+                    }
+                }
+
+                state.pushOperator(token, binaryOperator, operatorDef.precedence, { isIdempotent: true });
+            },
+
+            nextRuleNames: new Set(
+            [
+                "unaryOperator",
+                "debugOperator",
+                "literal",
+                "symbolLookup",
+                "openingParenthesis",
+            ]),
         },
-        "/": {
-            binary: { precedence: 3, execute: (a,b) => MychExpression.coerceNumber(a) / MychExpression.coerceNumber(b) }
+        propertyLookup:
+        {
+            description: "property lookup",
+            tokenType: "propertyOperator",
+
+            processToken: function(token, state, context)
+            {
+                function propertyLookupOperator(evaluatorStruct, evaluatorKey)
+                {
+                    return function* propertyLookupEvaluator(variables)
+                    {
+                        let valueStruct = yield* evaluatorStruct(variables);
+                        let valueKey = MychExpression.coerceString(yield* evaluatorKey(variables));
+
+                        if (valueStruct && valueStruct.getProperty instanceof Function)
+                        {
+                            return valueStruct.getProperty(valueKey);
+                        }
+
+                        return context.getprop(valueStruct, valueKey);
+                    }
+                }
+
+                state.pushOperator(token, propertyLookupOperator, 0);
+            },
+
+            nextRuleNames: new Set(
+            [
+                "propertyName",
+                "propertyExpression",
+            ]),
         },
-        "%": {
-            binary: { precedence: 3, execute: (a,b) => ((an,bn) => ((an % bn) + bn) % bn)(MychExpression.coerceNumber(a), MychExpression.coerceNumber(b)) }
+        propertyName:
+        {
+            description: "property name",
+            tokenType: "identifier",
+
+            processToken: function(token, state, context)
+            {
+                function* propertyNameEvaluator(variables)
+                {
+                    return token.value;
+                }
+
+                state.pushEvaluator(token, propertyNameEvaluator, { isConstant: true });
+            },
+
+            nextRuleNames: new Set(
+            [
+                "binaryOperator",
+                "propertyLookup",
+                "listLookup",
+                "closingParenthesis",
+                "closingBracket",
+                "endOfExpression",
+            ]),
         },
-        "+": {
-            unary:  { precedence: 2, execute: (a) => a },
-            binary: { precedence: 4, execute: (a,b) => MychExpression.coerceNumber(a) + MychExpression.coerceNumber(b) }
+        propertyExpression:
+        {
+            description: "opening parenthesis (for property expression)",
+            tokenType: "openingParenthesis",
+
+            processToken: function(token, state, context)
+            {
+                state.startGroup(token);
+            },
+
+            nextRuleNames: new Set(
+            [
+                "unaryOperator",
+                "debugOperator",
+                "literal",
+                "symbolLookup",
+                "openingParenthesis",
+            ]),
+            closeRuleNames: new Set(
+            [
+                "closingParenthesis",
+            ]),
         },
-        "-": {
-            unary:  { precedence: 2, execute: (a) => -MychExpression.coerceNumber(a) },
-            binary: { precedence: 4, execute: (a,b) => MychExpression.coerceNumber(a) - MychExpression.coerceNumber(b) }
+        debugOperator:
+        {
+            description: "debug operator",
+            tokenType: "debugOperator",
+
+            processToken: function(token, state, context)
+            {
+                let debugPrecedence;
+
+                switch (token.value.length)
+                {
+                    case 1: debugPrecedence = MychExpression.minOperatorPrecedence - 1; break;
+                    case 2: debugPrecedence = MychExpression.binaryOperatorDefs["<"].precedence - 1; break;
+                    case 3: debugPrecedence = MychExpression.maxOperatorPrecedence + 1; break;
+                }
+
+                let prevOperator = state.operatorStack[state.operatorStack.length - 1];
+                let maxDebugPrecedence = prevOperator ? prevOperator.precedence : MychExpression.maxOperatorPrecedence + 1;
+
+                function debugOperator(evaluator)
+                {
+                    let resultSourceBegin = evaluator.sourceOffset;
+                    let resultSourceEnd = evaluator.sourceOffset + evaluator.sourceLength;
+
+                    return function* debugOperatorEvaluator(variables)
+                    {
+                        let result = yield* evaluator(variables);
+                        context.$debugSendExpression(result, token.source, resultSourceBegin, resultSourceEnd);
+                        return result;
+                    }
+                }
+
+                state.pushOperator(token, debugOperator, Math.min(debugPrecedence, maxDebugPrecedence));
+            },
+
+            nextRuleNames: new Set(
+            [
+                "unaryOperator",
+                "literal",
+                "symbolLookup",
+                "openingParenthesis",
+            ]),
         },
-        "&": {
-            binary: { precedence: 5, execute: (a,b) => MychExpression.coerceString(a) + MychExpression.coerceString(b) }
+        symbolLookup:
+        {
+            description: "variable or function name",
+            tokenType: "identifier",
+
+            processToken: function(token, state, context)
+            {
+                function* symbolLookupEvaluator(variables)
+                {
+                    let symbolContext = (token.value in variables) ? variables : context;
+                    let symbolValue = symbolContext[token.value];
+
+                    if (symbolValue instanceof Function)
+                    {
+                        // call symbolValue function as method of symbolContext
+                        return (...args) => symbolValue.apply(symbolContext, args);
+                    }
+                    
+                    return symbolValue;
+                }
+
+                state.pushEvaluator(token, symbolLookupEvaluator);
+            },
+
+            nextRuleNames: new Set(
+            [
+                "binaryOperator",
+                "propertyLookup",
+                "call",
+                "listLookup",
+                "closingParenthesis",
+                "closingBracket",
+                "endOfExpression",
+            ]),
         },
-        "<": {
-            binary: { precedence: 6, execute: (a,b) => MychExpression.coerceNumber(a) < MychExpression.coerceNumber(b) }
+        literal:
+        {
+            description: "literal value",
+            tokenType: "literal",
+
+            processToken: function(token, state, context)
+            {
+                function* literalEvaluator(variables)
+                {
+                    return token.value;
+                }
+
+                state.pushEvaluator(token, literalEvaluator, { isConstant: true });
+            },
+
+            nextRuleNames: new Set(
+            [
+                "binaryOperator",
+                "propertyLookup",
+                "closingParenthesis",
+                "closingBracket",
+                "endOfExpression",
+            ]),
         },
-        "<=": {
-            binary: { precedence: 6, execute: (a,b) => MychExpression.coerceNumber(a) <= MychExpression.coerceNumber(b) }
+        call:
+        {
+            description: "opening parenthesis (for function arguments)",
+            tokenType: "openingParenthesis",
+
+            processToken: function(token, state, context)
+            {
+                function callOperator(funcEvaluator, argsEvaluator)
+                {
+                    return function* callEvaluator(variables)
+                    {
+                        let func = yield* funcEvaluator(variables);
+                        let args = argsEvaluator ? MychExpression.coerceArgs(yield* argsEvaluator(variables)) : [];
+
+                        if (func instanceof Function)
+                        {
+                            let funcResult = func(...args);
+                            return (funcResult && funcResult.next) ? (yield* funcResult) : funcResult;
+                        }
+
+                        throw new MychExpressionError("evaluate", (func ? "invalid function" : "unknown function"), token.source, token.offset);
+                    }
+                }
+
+                state.pushOperator(token, callOperator, -1);
+                state.startGroup(token);
+            },
+
+            nextRuleNames: new Set(
+            [
+                "closingParenthesisEmpty",
+                "unaryOperator",
+                "debugOperator",
+                "literal",
+                "symbolLookup",
+                "openingParenthesis",
+            ]),
+            closeRuleNames: new Set(
+            [
+                "closingParenthesis",
+                "closingParenthesisEmpty",
+            ]),
         },
-        ">": {
-            binary: { precedence: 6, execute: (a,b) => MychExpression.coerceNumber(a) > MychExpression.coerceNumber(b) }
+        openingParenthesis:
+        {
+            description: "opening parenthesis (for expression grouping)",
+            tokenType: "openingParenthesis",
+
+            processToken: function(token, state, context)
+            {
+                state.startGroup(token);
+            },
+
+            nextRuleNames: new Set(
+            [
+                "unaryOperator",
+                "debugOperator",
+                "literal",
+                "symbolLookup",
+                "openingParenthesis",
+            ]),
+            closeRuleNames: new Set(
+            [
+                "closingParenthesis",
+            ]),
         },
-        ">=": {
-            binary: { precedence: 6, execute: (a,b) => MychExpression.coerceNumber(a) >= MychExpression.coerceNumber(b) }
+        closingParenthesis:
+        {
+            description: "closing parenthesis",
+            tokenType: "closingParenthesis",
+
+            processToken: function(token, state, context)
+            {
+                state.reduceGroup(token);
+            },
+
+            nextRuleNames: new Set(
+            [
+                "binaryOperator",
+                "propertyLookup",
+                "listLookup",
+                "closingParenthesis",
+                "closingBracket",
+                "endOfExpression",
+            ]),
         },
-        "==": {
-            binary: { precedence: 7, execute: (a,b) => MychExpression.coerceNumber(a) == MychExpression.coerceNumber(b) }
+        closingParenthesisEmpty:
+        {
+            description: "closing parenthesis (for empty argument list)",
+            tokenType: "closingParenthesis",
+
+            processToken: function(token, state, context)
+            {
+                state.pushEvaluator(token, undefined, { isConstant: true });
+                state.reduceGroup(token);
+            },
+
+            nextRuleNames: new Set(
+            [
+                "binaryOperator",
+                "propertyLookup",
+                "listLookup",
+                "closingParenthesis",
+                "closingBracket",
+                "endOfExpression",
+            ]),
         },
-        "!=": {
-            binary: { precedence: 7, execute: (a,b) => MychExpression.coerceNumber(a) != MychExpression.coerceNumber(b) }
+        listLookup:
+        {
+            description: "opening bracket (for array subscript)",
+            tokenType: "openingBracket",
+
+            processToken: function(token, state, context)
+            {
+                function listLookupOperator(listEvaluator, indexEvaluator)
+                {
+                    return function* listLookupEvaluator(variables)
+                    {
+                        let list = MychExpression.coerceList(yield* listEvaluator(variables));
+                        let index = MychExpression.coerceNumber(yield* indexEvaluator(variables));
+
+                        return (index >= 0) ? list[Math.floor(index)] : list[Math.floor(list.length - index)];
+                    }
+                }
+
+                state.pushOperator(token, listLookupOperator, 0, { isIdempotent: true });
+                state.startGroup(token);
+            },
+
+            nextRuleNames: new Set(
+            [
+                "unaryOperator",
+                "debugOperator",
+                "literal",
+                "symbolLookup",
+                "openingParenthesis",
+            ]),
+            closeRuleNames: new Set(
+            [
+                "closingBracket",
+            ]),
         },
-        "eq": {
-            binary: { precedence: 7, execute: (a,b) => MychExpression.coerceString(a) == MychExpression.coerceString(b) }
+        closingBracket:
+        {
+            description: "closing bracket",
+            tokenType: "closingBracket",
+
+            processToken: function(token, state, context)
+            {
+                state.reduceGroup(token);
+            },
+
+            nextRuleNames: new Set(
+            [
+                "binaryOperator",
+                "propertyLookup",
+                "closingParenthesis",
+                "closingBracket",
+                "endOfExpression",
+            ]),
         },
-        "ne": {
-            binary: { precedence: 7, execute: (a,b) => MychExpression.coerceString(a) != MychExpression.coerceString(b) }
-        },
-        "not": {
-            unary:  { precedence: 8, execute: (a) => !MychExpression.coerceBoolean(a) },
-        },
-        "and": {
-            binary: { precedence: 9, execute: (a,b) => MychExpression.coerceBoolean(a) && MychExpression.coerceBoolean(b) }
-        },
-        "or": {
-            binary: { precedence: 10, execute: (a,b) => MychExpression.coerceBoolean(a) || MychExpression.coerceBoolean(b) }
-        },
-        ",": {
-            binary: { precedence: 11, execute: (a,b) => MychExpression.coerceArgs(a).concat(MychExpression.coerceArgs(b)) }
+        endOfExpression:
+        {
+            description: "end of expression",
+            tokenType: "endOfExpression",
+            nextRuleNames: new Set(),
+
+            processToken: function(token, state, context)
+            {
+                state.reduceGroup(token);
+            },
         },
     };
 
-    static minOperatorPrecedence = Math.min(...Object.values(MychExpression.operators).map(variants => Object.values(variants).map(variant => variant.precedence)).flat());
-    static maxOperatorPrecedence = Math.max(...Object.values(MychExpression.operators).map(variants => Object.values(variants).map(variant => variant.precedence)).flat());
+    static unaryOperatorDefs =
+    {
+        "+":
+        {
+            precedence: 2,
+            evaluate: valueA => valueA,
+        },
+        "-":
+        {
+            precedence: 2,
+            coerceValue: MychExpression.coerceNumber,
+            evaluate: value => -value,
+        },
+        "not":
+        {
+            precedence: 8,
+            coerceValue: MychExpression.coerceBoolean,
+            evaluate: value => !value,
+        },
+    };
+
+    static binaryOperatorDefs =
+    {
+        "**":
+        {
+            precedence: 1,
+            rightAssociative: true,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA ** valueB,
+        },
+        "*":
+        {
+            precedence: 3,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA * valueB,
+        },
+        "/":
+        {
+            precedence: 3,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA / valueB,
+        },
+        "%":
+        {
+            precedence: 3,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => ((valueA % valueB) + valueB) % valueB,
+        },
+        "+":
+        {
+            precedence: 4,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA + valueB,
+        },
+        "-":
+        {
+            precedence: 4,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA - valueB,
+        },
+        "&":
+        {
+            precedence: 5,
+            coerceValueA: MychExpression.coerceString,
+            coerceValueB: MychExpression.coerceString,
+            evaluate: (valueA, valueB) => valueA + valueB,
+        },
+        "<":
+        {
+            precedence: 6,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA < valueB,
+        },
+        "<=":
+        {
+            precedence: 6,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA <= valueB,
+        },
+        ">":
+        {
+            precedence: 6,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA > valueB,
+        },
+        ">=":
+        {
+            precedence: 6,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA >= valueB,
+        },
+        "==":
+        {
+            precedence: 7,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA == valueB,
+        },
+        "!=":
+        {
+            precedence: 7,
+            coerceValueA: MychExpression.coerceNumber,
+            coerceValueB: MychExpression.coerceNumber,
+            evaluate: (valueA, valueB) => valueA != valueB,
+        },
+        "eq":
+        {
+            precedence: 7,
+            coerceValueA: MychExpression.coerceString,
+            coerceValueB: MychExpression.coerceString,
+            evaluate: (valueA, valueB) => valueA == valueB,
+        },
+        "ne":
+        {
+            precedence: 7,
+            coerceValueA: MychExpression.coerceString,
+            coerceValueB: MychExpression.coerceString,
+            evaluate: (valueA, valueB) => valueA != valueB,
+        },
+        "and":
+        {
+            precedence: 9,
+            coerceValueA: MychExpression.coerceBoolean,
+            coerceValueB: MychExpression.coerceBoolean,
+            evaluate: (valueA, valueB) => valueA && valueB,
+        },
+        "or":
+        {
+            precedence: 10,
+            coerceValueA: MychExpression.coerceBoolean,
+            coerceValueB: MychExpression.coerceBoolean,
+            evaluate: (valueA, valueB) => valueA || valueB,
+        },
+        ",":
+        {
+            precedence: 11,
+            coerceValueA: MychExpression.coerceArgs,
+            coerceValueB: MychExpression.coerceArgs,
+            evaluate: (valueA, valueB) => valueA.concat(valueB),
+        },
+    };
+
+    static createRuleNamesByTokenType()
+    {
+        let ruleNamesByTokenType = {};
+
+        for (let [ruleName, rule] of Object.entries(MychExpression.rules))
+        {
+            let tokenTypes = rule.tokenType;
+
+            for (let tokenType of Array.isArray(tokenTypes) ? tokenTypes : [tokenTypes])
+            {
+                ruleNamesByTokenType[tokenType] || (ruleNamesByTokenType[tokenType] = []);
+                ruleNamesByTokenType[tokenType].push(ruleName);
+            }
+        }
+
+        return ruleNamesByTokenType;
+    }
+
+    static ruleNamesByTokenType = MychExpression.createRuleNamesByTokenType();
+
+    static createCloseRuleNames()
+    {
+        let closeRuleNames = new Set([ "endOfExpression" ]);
+
+        for (let rule of Object.values(MychExpression.rules))
+        {
+            if (rule.closeRuleNames)
+            {
+                rule.closeRuleNames.forEach(closeRuleName => closeRuleNames.add(closeRuleName));
+            }
+        }
+
+        return closeRuleNames;
+    }
+
+    static closeRuleNames = MychExpression.createCloseRuleNames();
+
+    static minOperatorPrecedence = Math.min(
+        ...Object.values(MychExpression.unaryOperatorDefs).map(operatorDef => operatorDef.precedence),
+        ...Object.values(MychExpression.binaryOperatorDefs).map(operatorDef => operatorDef.precedence));
+
+    static maxOperatorPrecedence = Math.max(
+        ...Object.values(MychExpression.unaryOperatorDefs).map(operatorDef => operatorDef.precedence),
+        ...Object.values(MychExpression.binaryOperatorDefs).map(operatorDef => operatorDef.precedence));
+
+    static createPrecedenceIsRightAssociative()
+    {
+        let precedenceIsRightAssociative = [];
+
+        for (let operatorDef of Object.values(MychExpression.binaryOperatorDefs))
+        {
+            let operatorPrecedence = operatorDef.precedence;
+            let operatorIsRightAssociative = !!operatorDef.rightAssociative;
+
+            if (precedenceIsRightAssociative[operatorPrecedence] == undefined)
+            {
+                precedenceIsRightAssociative[operatorPrecedence] = operatorIsRightAssociative;
+            }
+            else if (precedenceIsRightAssociative[operatorPrecedence] != operatorIsRightAssociative)
+            {
+                // associativity must be consistent on each precedence level to avoid ambiguities
+                throw "MychExpression internal error: inconsistent associativity for precedence level " + operatorPrecedence;
+            }
+        }
+
+        return precedenceIsRightAssociative;
+    }
+
+    static precedenceIsRightAssociative = MychExpression.createPrecedenceIsRightAssociative();
 
     static createTokenRegExp()
     {
-        function compareLengthDecreasing(string1, string2)
-        {
-            // Sort in decreasing order of string length.
-            return (string2.length - string1.length);
-        }
-
         function createOperatorRegExpSource(operator)
         {
-            // Escape all characters that might have special meaning and add boundary assertions.
+            // escape all characters that might have special meaning and add boundary assertions
             return operator.replace(/(\W)/g, "\\$1").replace(/^\b|\b$/g, "\\b");
         }
 
-        let operatorRegExpSource = Object.keys(MychExpression.operators).sort(compareLengthDecreasing).map(createOperatorRegExpSource).join("|");
+        let operatorTokens = new Set([
+            ...Object.keys(MychExpression.unaryOperatorDefs),
+            ...Object.keys(MychExpression.binaryOperatorDefs)]);
+
+        let operatorRegExpSource = [...operatorTokens].sort((tokenA, tokenB) => tokenB.length - tokenA.length).map(createOperatorRegExpSource).join("|")
 
         let tokenPatterns =
         {
-            operator:             operatorRegExpSource,
-            debug:                /\?{1,3}/,
-            literalNumber:        /(\.\d+|\d+(\.\d*)?)([eE][-+]?\d+)?/,
-            literalBoolean:       /\b(true|false)\b/,
-            literalStringDouble:  /"([^"\\]|\\.)*"?/,
-            literalStringSingle:  /'([^'\\]|\\.)*'?/,
-            identifier:           /\b\w+\b|\$\[\[\w+\]\]/,
-            parenthesis:          /[()]/,
-            whitespace:           /\s+/,
-            unsupported:          /.+/,
+            unaryOrBinaryOperator:  operatorRegExpSource,
+
+            propertyOperator:       /\./,
+            debugOperator:          /\?{1,3}/,
+
+            literalNumber:          /(\.\d+|\d+(\.\d*)?)([eE][-+]?\d+)?/,
+            literalBoolean:         /\b(true|false)\b/,
+            literalStringDouble:    /"([^"\\]|\\.)*"?/,
+            literalStringSingle:    /'([^'\\]|\\.)*'?/,
+
+            identifier:             /\b[A-Za-z_]\w*\b|\$\[\[\w+\]\]/,
+
+            openingParenthesis:     /\(/,
+            closingParenthesis:     /\)/,
+            openingBracket:         /\[/,
+            closingBracket:         /\]/,
+
+            whitespace:             /\s+/,
+            unsupported:            /.+/,
         }
 
         function createTokenRegExpSource([type, pattern])
         {
-            if (pattern instanceof RegExp)
-            {
-                pattern = pattern.source;
-            }
-
-            return "(?<" + type + ">" + pattern + ")";
+            return "(?<" + type + ">" + (pattern instanceof RegExp ? pattern.source : pattern) + ")";
         }
 
         return new RegExp(Object.entries(tokenPatterns).map(createTokenRegExpSource).join("|"), "g");
@@ -3482,9 +4125,114 @@ class MychExpression
 
     static tokenRegExp = MychExpression.createTokenRegExp();
 
-    parse(source)
+    static ParseState = class
     {
-        let tokens = [];
+        evaluatorStack = [];
+        operatorStack = [{ precedence: MychExpression.maxOperatorPrecedence + 1, operator: undefined, sourceOffset: 0 }];
+
+        pushEvaluator(token, evaluator, attributes = {})
+        {
+            if (evaluator)
+            {
+                evaluator.sourceOffset = token.offset;
+                evaluator.sourceLength = token.length;
+
+                Object.assign(evaluator, attributes);
+            }
+
+            this.evaluatorStack.push(evaluator);
+        }
+
+        startGroup(token)
+        {
+            this.operatorStack.push({ operator: undefined, sourceOffset: token.offset, sourceLength: token.length });
+        }
+
+        reduceGroup(token)
+        {
+            let operatorEntry;
+            let operatorEvaluator;
+
+            while (this.operatorStack.length > 0)
+            {
+                operatorEntry = this.operatorStack.pop();
+
+                if (!operatorEntry.operator)
+                {
+                    break;
+                }
+
+                let numArgEvaluators = operatorEntry.operator.length;
+                let argEvaluators = this.evaluatorStack.splice(-numArgEvaluators);
+
+                operatorEvaluator = operatorEntry.operator(...argEvaluators);
+
+                operatorEvaluator.argEvaluators = argEvaluators;
+                operatorEvaluator.sourceOffset = Math.min(operatorEntry.sourceOffset, ...argEvaluators.filter(evaluator => evaluator).map(evaluator => evaluator.sourceOffset));
+                operatorEvaluator.sourceLength = Math.max(operatorEntry.sourceOffset + operatorEntry.sourceLength, ...argEvaluators.filter(evaluator => evaluator).map(evaluator => evaluator.sourceOffset + evaluator.sourceLength)) - operatorEvaluator.sourceOffset;
+                operatorEvaluator.isConstant = operatorEntry.isIdempotent && argEvaluators.every(evaluator => !evaluator || evaluator.isConstant);
+
+                this.evaluatorStack.push(operatorEvaluator);
+            }
+
+            operatorEvaluator || (operatorEvaluator = this.evaluatorStack[this.evaluatorStack.length - 1]);
+
+            if (operatorEvaluator)
+            {
+                operatorEvaluator.sourceOffset = operatorEntry.sourceOffset;
+                operatorEvaluator.sourceLength = token.offset + token.length - operatorEvaluator.sourceOffset;
+            }
+        }
+
+        pushOperator(token, operator, precedence, attributes = {})
+        {
+            if (operator.length > 1)
+            {
+                // keep same-precedence operators if precedence level is right-associative
+                let stopPrecedence = MychExpression.precedenceIsRightAssociative[precedence] ? precedence : precedence + 0.5;
+
+                let operatorEntry;
+                let operatorEvaluator;
+
+                while (this.operatorStack.length > 0)
+                {
+                    operatorEntry = this.operatorStack.pop();
+
+                    if (!operatorEntry.operator || operatorEntry.precedence >= stopPrecedence)
+                    {
+                        this.operatorStack.push(operatorEntry);
+                        break;
+                    }
+
+                    let numArgEvaluators = operatorEntry.operator.length;
+                    let argEvaluators = this.evaluatorStack.splice(-numArgEvaluators);
+
+                    operatorEvaluator = operatorEntry.operator(...argEvaluators);
+
+                    operatorEvaluator.argEvaluators = argEvaluators;
+                    operatorEvaluator.sourceOffset = Math.min(operatorEntry.sourceOffset, ...argEvaluators.filter(evaluator => evaluator).map(evaluator => evaluator.sourceOffset));
+                    operatorEvaluator.sourceLength = Math.max(operatorEntry.sourceOffset + operatorEntry.sourceLength, ...argEvaluators.filter(evaluator => evaluator).map(evaluator => evaluator.sourceOffset + evaluator.sourceLength)) - operatorEvaluator.sourceOffset;
+                    operatorEvaluator.isConstant = operatorEntry.isIdempotent && argEvaluators.every(evaluator => !evaluator || evaluator.isConstant);
+            
+                    this.evaluatorStack.push(operatorEvaluator);
+                }
+            }
+
+            this.operatorStack.push({ precedence: precedence, operator: operator, sourceOffset: token.offset, sourceLength: token.length, ...attributes });
+        }
+    }
+
+    parse(source, context)
+    {
+        if (context == undefined)
+        {
+            throw "MychExpression internal error: no parse context";
+        }
+
+        this.source = source;
+        this.context = context;
+        this.tokens = [];
+
         let tokenMatch;
 
         MychExpression.tokenRegExp.lastIndex = 0;
@@ -3505,6 +4253,15 @@ class MychExpression
 
             switch (tokenType)
             {
+                case "unaryOrBinaryOperator":
+                {
+                    let isUnary = tokenValue in MychExpression.unaryOperatorDefs;
+                    let isBinary = tokenValue in MychExpression.binaryOperatorDefs;
+
+                    tokenType = (isUnary && isBinary) ? "unaryOrBinaryOperator" : isUnary ? "unaryOperator" : "binaryOperator";
+                }
+                break;
+
                 case "literalNumber":
                 {
                     tokenType = "literal";
@@ -3535,232 +4292,124 @@ class MychExpression
             }
 
             let offset = tokenMatch.index;
-            let offsetEnd = tokenMatch.index + tokenMatch[0].length;
+            let length = tokenMatch[0].length;
 
-            tokens.push({ type: tokenType, offset: offset, offsetEnd: offsetEnd, value: tokenValue });
+            this.tokens.push({ type: tokenType, value: tokenValue, source: source, offset: offset, length: length });
         }
 
-        this.source = source;
-        this.tokens = tokens;
+        this.tokens.push({ type: "endOfExpression", source: source, offset: source.length, length: 0 });
+
+        let expectedNextRuleNames = MychExpression.rules.unaryOperator.nextRuleNames;
+        let expectedCloseRuleNamesStack = [ new Set([ "endOfExpression" ]) ];
+
+        function expectedRuleName(ruleName)
+        {
+            return expectedNextRuleNames.has(ruleName) && (!MychExpression.closeRuleNames.has(ruleName) || expectedCloseRuleNamesStack[0].has(ruleName));
+        }
+
+        for (let token of this.tokens)
+        {
+            token.ruleName = MychExpression.ruleNamesByTokenType[token.type].find(expectedRuleName);
+
+            if (!token.ruleName)
+            {
+                let expectedRuleDescriptions = [...expectedNextRuleNames].filter(expectedRuleName).map(ruleName => MychExpression.rules[ruleName].description);  
+                throw new MychExpressionError("parse", "expected " + expectedRuleDescriptions.join(", or "), source, token.offset);
+            }
+
+            if (MychExpression.closeRuleNames.has(token.ruleName))
+            {
+                expectedCloseRuleNamesStack.shift();
+            }
+
+            let rule = MychExpression.rules[token.ruleName];
+
+            if (!rule)
+            {
+                let extraneousRuleDescription = MychExpression.rules[token.ruleName].description;
+                throw new MychExpressionError("parse", "extraneous " + extraneousRuleDescription, source, token.offset);
+            }
+
+            if (rule.closeRuleNames)
+            {
+                expectedCloseRuleNamesStack.unshift(rule.closeRuleNames);
+            }
+
+            expectedNextRuleNames = rule.nextRuleNames;
+        }
+
+        if (expectedCloseRuleNamesStack.length > 0)
+        {
+            console.log("stack of expected close rules not empty:", expectedCloseRuleNamesStack);
+            throw "MychExpression internal error: stack of expected close rules not empty";
+        }
+
+        let state = new MychExpression.ParseState();
+
+        for (let token of this.tokens)
+        {
+            let rule = MychExpression.rules[token.ruleName];
+
+            try
+            {
+                rule.processToken(token, state, context);
+            }
+            catch (exception)
+            {
+                throw new MychExpressionError("parse", exception.toString(), source, token.offset, exception);
+            }
+        }
+
+        if (state.evaluatorStack.length != 1)
+        {
+            console.log("expression not reduced to exactly one evaluator:", this, state);
+            throw "MychExpression internal error: expression not reduced to exactly one evaluator";
+        }
+
+        this.evaluator = state.evaluatorStack[0];
     }
 
-    *evaluate(variables, context)
+    isConstant()
     {
-        let valueStack = [];
-        let operationStack = [];
+        return this.evaluator && this.evaluator.isConstant;
+    }
 
-        function* reduce(precedence)
+    evaluateConstant()
+    {
+        if (!this.evaluator)
         {
-            while (operationStack.length > 0)
-            {
-                let operation = operationStack[operationStack.length - 1];
-
-                if (operation.type == "parenthesis")
-                {
-                    break;
-                }
-
-                if (precedence != undefined && operation.precedence > precedence)
-                {
-                    break;
-                }
-
-                operationStack.pop();
-
-                let executionArguments = valueStack.splice(-operation.operands);
-                let executionResult;
-
-                if (operation.type == "function")
-                {
-                    executionArguments = executionArguments.flatMap(arg => arg instanceof MychExpressionArgs ? arg : [arg]);
-                    executionResult = operation.execute.apply(operation.context, executionArguments);
-
-                    if (executionResult && executionResult.next)
-                    {
-                        executionResult = yield* executionResult;
-                    }
-                }
-                else
-                {
-                    executionResult = operation.execute.apply(this, executionArguments);
-                }
-
-                valueStack.push(executionResult);
-            }
+            throw new MychExpressionError("evaluate", "no expression parsed prior to evaluation", "", 0);
         }
 
-        let expectClosing = [{}];
-        let expectTokens = { operator: "unary", debug: "any", literal: "any", identifier: "any", parenthesis: "opening" };
-
-        function getExpectDescription()
+        if (!this.evaluator.isConstant)
         {
-            return Object.entries(expectTokens).filter(([type, qualifier]) => qualifier).map(([type, qualifier]) => qualifier + " " + type).join(", ");
+            throw new MychExpressionError("evaluate", "no expression parsed prior to evaluation", "", 0);
         }
 
-        let maxEvaluatedTokenIndex;
+        let resultContainer = this.evaluator(undefined).next();
 
-        for (let tokenIndex = 0; tokenIndex < this.tokens.length; ++tokenIndex)
+        if (!resultContainer.done)
         {
-            let token = this.tokens[tokenIndex];
-
-            let tokenQualifier = "any";
-            let expectTokenQualifiers = [expectTokens[token.type]].flat();
-
-            let operator = undefined;
-
-            switch (token.type)
-            {
-                case "operator":
-                {
-                    let operatorVariants = MychExpression.operators[token.value];
-                    let operatorType = expectTokenQualifiers.find(qualifier => operatorVariants[qualifier]);
-                    operator = operatorVariants[operatorType];
-                    tokenQualifier = operatorType || Object.keys(operatorVariants).join("/");
-                }
-                break;
-
-                case "parenthesis":
-                {
-                    tokenQualifier = (token.value == "(" ? "opening" : "closing");
-                }
-                break;
-            }
-
-            if (!expectTokenQualifiers.includes(tokenQualifier))
-            {
-                let expectDescription = getExpectDescription();
-                throw new MychExpressionError("evaluate", tokenQualifier + " " + token.type + " not expected here (expected " + expectDescription + ")", this.source, token.offset);
-            }
-
-            switch (token.type)
-            {
-                case "operator":
-                {
-                    if (tokenQualifier == "unary")
-                    {
-                        operationStack.push({ type: "operator", name: token.value, operands: 1, precedence: operator.precedence, execute: operator.execute });
-                        expectTokens = { operator: "unary", debug: "any", literal: "any", identifier: "any", parenthesis: "opening" };
-                    }
-                    else
-                    {
-                        maxEvaluatedTokenIndex = tokenIndex - 1;
-
-                        yield* reduce(operator.associativity == "right" ? operator.precedence - 1 : operator.precedence);
-
-                        operationStack.push({ type: "operator", name: token.value, operands: 2, precedence: operator.precedence, execute: operator.execute });
-                        expectTokens = { operator: "unary", debug: "any", literal: "any", identifier: "any", parenthesis: "opening" };
-                    }
-                }
-                break;
-
-                case "debug":
-                {
-                    let debugExpression = this;
-                    let debugTokenIndex = tokenIndex;
-
-                    function debug(value)
-                    {
-                        let sourceBegin = debugExpression.tokens[debugTokenIndex].offset;
-                        let sourceEnd = debugExpression.tokens[maxEvaluatedTokenIndex].offsetEnd;
-
-                        context.$debugSendExpression(value, debugExpression.source, sourceBegin, sourceEnd);
-                    
-                        return value;
-                    }
-
-                    let debugPrecedence;
-
-                    switch (token.value.length)
-                    {
-                        case 1: debugPrecedence = MychExpression.minOperatorPrecedence - 1; break;
-                        case 2: debugPrecedence = MychExpression.operators["<"].binary.precedence - 1; break;
-                        case 3: debugPrecedence = MychExpression.maxOperatorPrecedence + 1; break;
-                    }
-
-                    let prevOperation = operationStack[operationStack.length - 1];
-                    let maxDebugPrecedence = (prevOperation ? prevOperation.precedence : MychExpression.maxOperatorPrecedence + 1);
-
-                    operationStack.push({ type: "debug", name: token.value, operands: 1, precedence: Math.min(debugPrecedence, maxDebugPrecedence), execute: debug });
-                    expectTokens = { operator: "unary", literal: "any", identifier: "any", parenthesis: "opening" };
-                }
-                break;
-
-                case "literal":
-                {
-                    valueStack.push(token.value);
-                    expectTokens = { operator: "binary", parenthesis: expectClosing[0].parenthesis };
-                }
-                break;
-
-                case "identifier":
-                {
-                    let identifierContext = variables;
-                    let identifierValue = variables[token.value];
-
-                    if (identifierValue == undefined)
-                    {
-                        identifierContext = context;
-                        identifierValue = context[token.value];
-                    }
-
-                    if (identifierValue instanceof Function)
-                    {
-                        operationStack.push({ type: "function", name: token.value, operands: 1, precedence: 0, execute: identifierValue, context: identifierContext });
-                        expectTokens = { parenthesis: "opening" };
-                    }
-                    else
-                    {
-                        valueStack.push(identifierValue);
-                        expectTokens = { operator: "binary", parenthesis: expectClosing[0].parenthesis };
-                    }
-                }
-                break;
-
-                case "parenthesis":
-                {
-                    if (token.value == "(")
-                    {
-                        operationStack.push({ type: "parenthesis", valueStackOffset: valueStack.length });
-                        expectClosing.unshift({ parenthesis: "closing" });
-                        expectTokens = { operator: "unary", debug: "any", literal: "any", identifier: "any", parenthesis: ["opening", "closing"] };
-                    }
-                    else
-                    {
-                        maxEvaluatedTokenIndex = tokenIndex - 1;
-
-                        yield* reduce();
-
-                        let openingParenthesisOperation = operationStack.pop();
-                        if (valueStack.length == openingParenthesisOperation.valueStackOffset)
-                        {
-                            valueStack.push(MychExpressionArgs.of());
-                        }
-
-                        expectClosing.shift();
-                        expectTokens = { operator: "binary", parenthesis: expectClosing[0].parenthesis };
-                    }
-                }
-                break;
-            }
+            console.log("constant expression yields value prior to return:", this, resultContainer);
+            throw "MychExpression internal error: constant expression yields value prior to return";
         }
 
-        if (expectTokens.operator != "binary")
+        if (resultContainer.value instanceof MychExpressionArgs)
         {
-            let expectDescription = getExpectDescription();
-            throw new MychExpressionError("evaluate", "expected " + expectDescription, this.source, this.source.length);
+            return MychExpression.coerceList(resultContainer.value);
         }
 
-        maxEvaluatedTokenIndex = this.tokens.length - 1;
+        return resultContainer.value;
+    }
 
-        yield* reduce();
-
-        if (operationStack.length != 0)
+    *evaluate(variables)
+    {
+        if (!this.evaluator)
         {
-            let expectDescription = getExpectDescription();
-            throw new MychExpressionError("evaluate", "expected " + expectDescription, this.source, this.source.length);
+            throw new MychExpressionError("evaluate", "no expression parsed prior to evaluation", "", 0);
         }
 
-        let result = valueStack[0];
+        let result = yield* this.evaluator(variables);
 
         if (result instanceof MychExpressionArgs)
         {

--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -4096,13 +4096,13 @@ class MychExpression
         {
             unaryOrBinaryOperator:  operatorRegExpSource,
 
-            propertyOperator:       /\./,
-            debugOperator:          /\?{1,3}/,
-
             literalNumber:          /(\.\d+|\d+(\.\d*)?)([eE][-+]?\d+)?/,
             literalBoolean:         /\b(true|false)\b/,
             literalStringDouble:    /"([^"\\]|\\.)*"?/,
             literalStringSingle:    /'([^'\\]|\\.)*'?/,
+
+            propertyOperator:       /\./,
+            debugOperator:          /\?{1,3}/,
 
             identifier:             /\b[A-Za-z_]\w*\b|\$\[\[\w+\]\]/,
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ You can also put a whole sequence of commands together, one after another in sep
 | Line | Commands | What happens?
 | ---- | -------- | -------------
 | 1    | _!mmm_ **chat:** Oh dear, I'm pretty banged up. | ***Finn:*** Oh dear, I'm pretty banged up.
-| 2    | _!mmm_ **do** setattr(sender, "HP", getattrmax(sender, "HP")) | *(set HP attribute to its maximum)*
-| 3    | _!mmm_ **chat:** /me is back at ${getattr(sender, "HP")} points. | ***Finn is back at 25 points.***
+| 2    | _!mmm_ **do** setattr(sender, "HP", sender.HP.max) | *(set HP attribute to its maximum)*
+| 3    | _!mmm_ **chat:** /me is back at ${sender.HP} points. | ***Finn is back at 25 points.***
 
 Each of these commands would be executed as soon as the MMM scripting engine receives it. That's possible because each of the commands above is *self-contained:* It has everything it needs to execute in the same line.
 
@@ -49,7 +49,7 @@ However, some commands enclose a *block* of other commands – for example, if y
 
 | Line | Commands | What happens?
 | ---- | -------- | -------------
-| 1    | _!mmm_ **if** getattr(sender, "HP") < 5 | *(check HP attribute)*
+| 1    | _!mmm_ **if** sender.HP < 5 | *(check HP attribute)*
 | 2    | _!mmm_     **chat:** /me is nearly dead! | ***Finn is nearly dead!***
 | 3    | _!mmm_ **end if**
 
@@ -115,7 +115,7 @@ You can use /me, /whisper, and any other Roll20 chat directives in a **chat** co
 | ---- | -------- | -------------
 | 1    | _!mmm_ **chat:** /me is bored. | ***Finn is bored.***
 | 2    | _!mmm_ **chat:** Attacking with [[1d20+12]] | ***Finn:*** Attacking with `14`
-| 3    | _!mmm_ **chat:** My half-life is ${getattr(sender, "HP") / 2}. | ***Finn:*** My half-life is 11.5.
+| 3    | _!mmm_ **chat:** My half-life is ${sender.HP / 2}. | ***Finn:*** My half-life is 11.5.
 
 If the template is completely absent, the **chat** command sends a line break instead of just nothing. Together with **combine chat** (described below) you can use this to add some visual structure to your chat messages without going to the extreme of just sending several separate messages (oh my!):
 
@@ -226,10 +226,10 @@ After the last iteration, the *variable* is deleted again. However, if you use *
 | ---- | -------- | -------------
 | 1    | _!mmm_ **script**
 | 2    | _!mmm_     **for** token **in** selected | *(loop over all selected tokens)*
-| 3    | _!mmm_         **exit for if** getattr(token, "HP") > 10 | *(exit loop early if token is healthy enough)*
+| 3    | _!mmm_         **exit for if** token.HP > 10 | *(exit loop early if token is healthy enough)*
 | 4    | _!mmm_     **end for**
 | 5    | _!mmm_     **if** token | *(did the loop exit early?)*
-| 6    | _!mmm_         **chat:** ${getattr(token, "name")} seems healthy enough! | ***Finn:*** Yorric seems healthy enough!
+| 6    | _!mmm_         **chat:** ${token.name} seems healthy enough! | ***Finn:*** Yorric seems healthy enough!
 | 7    | _!mmm_     **else**
 | 8    | _!mmm_         **chat:** Everyone seems pretty banged up.
 | 9    | _!mmm_     **end if**
@@ -255,8 +255,8 @@ Evaluates an expression and assigns its results to a variable. If the variable d
 | Line | Commands | What happens?
 | ---- | -------- | -------------
 | 1    | _!mmm_ **script**
-| 2    | _!mmm_     **set** CurCount = getattr(sender, "AmmoCount") | *(stores AmmoCount attribute value in CurCount variable)*
-| 3    | _!mmm_     **set** MaxCount = getattrmax(sender, "AmmoCount") | *(stores AmmoCount attribute max value in MaxCount variable)*
+| 2    | _!mmm_     **set** CurCount = sender.AmmoCount | *(stores AmmoCount attribute value in CurCount variable)*
+| 3    | _!mmm_     **set** MaxCount = sender.AmmoCount.max | *(stores AmmoCount attribute max value in MaxCount variable)*
 | 4    | _!mmm_     **set** FindProb = ?{Probability?\|100} / 100 | *(calculates FindProb variable from roll query result)*
 | 5    | _!mmm_     **set** FindCount = round(FindProb * (MaxCount - CurCount)) | *(calculates and assigns FindCount variable)*
 | 6    | _!mmm_     **set** CurCount = CurCount + FindCount | *(updates CurCount variable)*
@@ -288,12 +288,12 @@ If you want to use a default that's more complex than a simple expression, you c
 | 1    | _!mmm_ **script**
 | 2    | _!mmm_     **set customizable** WeaponName = **default** | *(use special default indicator value)*
 | 3    | _!mmm_     **if** isdefault(WeaponName) | *(check if WeaponName was left uncustomized)*
-| 4    | _!mmm_         **set** FirstWeaponSkill = getattr(sender, "repeating_attack_$0_skill") | *(get first weapon skill from character sheet)*
-| 5    | _!mmm_         **set** SecondWeaponSkill = getattr(sender, "repeating_attack_$1_skill") | *(get second weapon skill from character sheet)*
+| 4    | _!mmm_         **set** FirstWeaponSkill = sender.("repeating_attack_$0_skill") | *(get first weapon skill from character sheet)*
+| 5    | _!mmm_         **set** SecondWeaponSkill = sender.("repeating_attack_$1_skill") | *(get second weapon skill from character sheet)*
 | 6    | _!mmm_         **if** FirstWeaponSkill > SecondWeaponSkill | *(compare weapon skills)*
-| 7    | _!mmm_             **set** WeaponName = getattr(sender, "repeating_attack_$0_weapon") | *(default to first weapon if greater skill than second)*
+| 7    | _!mmm_             **set** WeaponName = sender.("repeating_attack_$0_weapon") | *(default to first weapon if greater skill than second)*
 | 8    | _!mmm_         **else**
-| 9    | _!mmm_             **set** WeaponName = getattr(sender, "repeating_attack_$1_weapon") | *(default to second weapon otherwise)*
+| 9    | _!mmm_             **set** WeaponName = sender.("repeating_attack_$1_weapon") | *(default to second weapon otherwise)*
 | 10   | _!mmm_         **end if**
 | 11   | _!mmm_     **end if**
 | 12   | _!mmm_     **chat:** /me attacks with ${WeaponName}! | ***Finn attacks with slingshot!***
@@ -308,8 +308,8 @@ Evaluates an expression. This is useful if the expression has side effects, e.g.
 
 | Line | Commands | What happens?
 | ---- | -------- | -------------
-| 1    | _!mmm_ **do** setattr(sender, "HP", min(getattr(sender, "HP") + [[1d6]], getattrmax(sender, "HP")) | *(add 1d6 HP, up to max HP)*
-| 2    | _!mmm_ **do** setattr(sender, "AmmoCount", getattr(sender, "AmmoCount") - 1) | *(decrement AmmoCount attribute)*
+| 1    | _!mmm_ **do** setattr(sender, "HP", min(sender.HP + [[1d6]], sender.HP.max) | *(add 1d6 HP, up to max HP)*
+| 2    | _!mmm_ **do** setattr(sender, "AmmoCount", sender.AmmoCount - 1) | *(decrement AmmoCount attribute)*
 | 3    | _!mmm_ **do** chat("/me likes chatting the hard way") | ***Finn likes chatting the hard way***
 
 
@@ -382,7 +382,7 @@ Consider this script:
 | ---- | -------- | -------------
 | 1    | _!mmm_ **script**
 | 2    | _!mmm_     **set customizable** AmmoName = "ammo" | *(assign default "ammo" to AmmoName)*
-| 3    | _!mmm_     **set** StartAmmoCount = getattr(sender, AmmoName) | *(get current ammo count from attribute "ammo")*
+| 3    | _!mmm_     **set** StartAmmoCount = sender.(AmmoName) | *(get current ammo count from attribute "ammo")*
 | 4    | _!mmm_     **if** StartAmmoCount == 0 | *(check if there's still ammo left)*
 | 5    | _!mmm_         **chat** **[**<span>OutOfAmmo</span>**]:** Out of ammo | ***MrBore:*** Out of ammo
 | 6    | _!mmm_     **else**
@@ -407,7 +407,7 @@ So if a player wants to customize the script, they just have to place a **custom
 | 5    | _!mmm_ **end customize**
 | 6    | _!mmm_ **script**
 | 7    | _!mmm_     **set customizable** AmmoName = "ammo" | *(assign "arrows" to AmmoName – ignore "ammo")*
-| 8    | _!mmm_     **set** StartAmmoCount = getattr(sender, AmmoName) | *(get current ammo count from attribute "arrows")*
+| 8    | _!mmm_     **set** StartAmmoCount = sender.(AmmoName) | *(get current ammo count from attribute "arrows")*
 | 9    | _!mmm_     **if** StartAmmoCount == 0 | *(check if there are still arrows left)*
 | 10   | _!mmm_         **chat** **[**<span>OutOfAmmo</span>**]:** Out of ammo | ***Finn:*** My quiver is empty! Lucky bastards!
 | 11   | _!mmm_     **else**
@@ -463,10 +463,10 @@ Like **chat** but made for debugging, so it does two things differently:
 
 | Line | Commands | What happens?
 | ---- | -------- | -------------
-| 1    | _!mmm_ **debug chat:** Current health: ${getattr("Finn", "HP")} | *(Whisper):*  Current health: `"23"`
-| 2    | _!mmm_ **debug chat:** Half health: ${getattr("Finn", "HP") / 2} | *(Whisper):*  Half health: `11.5`
-| 3    | _!mmm_ **debug chat:** Health not great: ${getattr("Finn", "HP") < 5} | *(Whisper):*  Health not great: `false`
-| 4    | _!mmm_ **debug chat:** Attribute tables: ${findattr("Finn")} | *(Whisper):*  Attribute tables: `"attack", "defense", "armor"`
+| 1    | _!mmm_ **debug chat:** Current health: ${sender.HP} | *(Whisper):*  Current health: `"23"`
+| 2    | _!mmm_ **debug chat:** Half health: ${sender.HP / 2} | *(Whisper):*  Half health: `11.5`
+| 3    | _!mmm_ **debug chat:** Health not great: ${sender.HP < 5} | *(Whisper):*  Health not great: `false`
+| 4    | _!mmm_ **debug chat:** Attribute tables: ${findattr(sender)} | *(Whisper):*  Attribute tables: `"attack", "defense", "armor"`
 
 The way this command is designed, you can just slap the `debug` keyword in front of any old `chat` command in your script to get some extra insight into how it's composed (or why it doesn't work the way you thought). This even works if there's a **[**_label_**]** for translation, which will be ignored.
 
@@ -484,7 +484,7 @@ Using **debug do** is most useful as a way to quickly get insight into the conte
 | Line | Commands | What happens?
 | ---- | -------- | -------------
 | 1    | _!mmm_ **debug do** CurrentHealth | *(Whisper):*  `9` ◄ `CurrentHealth`
-| 2    | _!mmm_ **debug do** getattr("Finn", "EP") | *(Whisper):*  `17` ◄ `getattr("Finn", "EP")`
+| 2    | _!mmm_ **debug do** sender.EP | *(Whisper):*  `17` ◄ `sender.EP`
 | 3    | _!mmm_ **debug do** "initial", CurrentHealth, CurrentEndurance | *(Whisper):*  `"initial", 9, 17` ◄ `"initial", CurrentHealth, CurrentEndurance`
 
 The effect of **debug do** is similar to putting a `???` debug operator (see [operators](#operators) below) in front of the expression of a regular **do** command. The difference between using one or the other is mostly one of convenience: Use `???` if you want to look into an expression that's integral part of your script's operation, and **debug do** if you plan on removing this debug output again once you're done debugging. It's just easier to keep track of what to keep and what to delete after a debugging session that way.
@@ -592,17 +592,17 @@ This behavior comes in handy if you want to append or prepend items to a list va
 | 6    | _!mmm_     **chat:** I've got ${things} | ***Finn:*** I've got true, 456, something, 123
 | 7    | _!mmm_ **end script**
 
-You can access any specific item in a list by its index:
+You can access any specific item in a list by its index using brackets like in `list[idx]` – the index can be any kind of expression, of course, not just a literal number:
 
 | Line | Commands | What happens?
 | ---- | -------- | -------------
 | 1    | _!mmm_ **script**
-| 2    | _!mmm_     **set** things = "hat", "rope", "slingshot", "pie"
+| 2    | _!mmm_     **set** things = "hat", "rope", "slingshot", "pie" | *(four list items – index goes from 0 to 3)*
 | 3    | _!mmm_     **chat:** My first thing is a ${things[0]}. | ***Finn:*** My first thing is a hat.
 | 4    | _!mmm_     **chat:** Next, a ${things[1]}. | ***Finn:*** Next, a rope.
 | 5    | _!mmm_     **set** lastThing = things[-1] | *(use negative index to count from the back)*
 | 6    | _!mmm_     **chat:** Last but not least, a ${lastThing}. | ***Finn:*** Last but not least, a pie.
-| 7    | _!mmm_     **set** noThing = things[99] | *(index out of bounds simply returns nothing)*
+| 7    | _!mmm_     **set** noThing = things[99] | *(index out of bounds simply returns an undefined value)*
 | 8    | _!mmm_ **end script**
 
 Of course, lists are most useful together with the [**for** loop](#mmm-for-variable-in-expression--end-for), which allows you to execute a block of code once for each list element in turn.
@@ -612,7 +612,7 @@ Of course, lists are most useful together with the [**for** loop](#mmm-for-varia
 
 Like in macros, you can query *attributes* in MMM expressions – and even create and update them if you like:
 
-- Use the `getattr()` and `getattrmax()` functions to query attribute values and max values.
+- Use `name`|`id.attrname`, `name`|`id.attrname.max`, or the `getattr()` and `getattrmax()` functions to query attribute values and max values.
 - Use the `setattr()` and `setattrmax()` functions to update (or, if necessary, create) attributes and max values.
 
 All of these functions take a *name|id* value as their first argument. You can pass a character ID, token ID, character name, or token name. (If you're passing a name and there's ambiguity, MMM always chooses characters over tokens, and if multiple characters should have the same name, it'll choose one at random. IDs are always unambiguous.)
@@ -785,7 +785,7 @@ With `findattr()` you can do all this without leaving the safe comfort of your c
 | 1    | _!mmm_ **chat:** Tables: ${findattr(sender)} | ***Finn:*** Tables: attack, defense, armor
 | 2    | _!mmm_ **chat:** Columns: ${findattr(sender, "attack")} | ***Finn:*** Columns: weapon, skill, damage
 | 3    | _!mmm_ **chat:** Attribute: ${findattr(sender, "attack", "weapon", "Slingshot", "damage")} | ***Finn:*** Attribute: repeating_attack_-MSxAHDgxtzAHdDAIopE_damage
-| 4    | _!mmm_ **chat:** Value: ${getattr(sender, findattr(sender, "attack", "weapon", "Slingshot", "damage"))} | ***Finn:*** Value: 1d6
+| 4    | _!mmm_ **chat:** Value: ${sender.(findattr(sender, "attack", "weapon", "Slingshot", "damage"))} | ***Finn:*** Value: 1d6
 
 What's happening in the last two lines above is that you're *selecting* one of the rows based on a condition: In this case, you want to get to the `damage` attribute of the `attack` table row that has the value `Slingshot` in its `weapon` column – so, the damage dealt by your slingshot. You can include several pairs of *column*, *value* to narrow down your selection if necessary.
 
@@ -803,8 +803,8 @@ Here is a script that will rotate the *selected* token so that it visually faces
 | 1    | _!mmm_ **script**
 | 2    | _!mmm_     **set** selectedToken = "@{selected\|token_id}" | *(get selected token – will be rotated)*
 | 3    | _!mmm_     **set** targetToken = "@{target\|Target\|token_id}" | *(get target token – selected token will be oriented facing it)*
-| 4    | _!mmm_     **set** targetOffsetRight = getattr(targetToken, "left") - getattr(selectedToken, "left") | *(calculate horizontal offset of target from selected)*
-| 5    | _!mmm_     **set** targetOffsetDown = getattr(targetToken, "top") - getattr(selectedToken, "top") | *(calculate vertical offset of target from selected)*
+| 4    | _!mmm_     **set** targetOffsetRight = targetToken.left - selectedToken.left | *(calculate horizontal offset of target from selected)*
+| 5    | _!mmm_     **set** targetOffsetDown = targetToken.top - selectedToken.top | *(calculate vertical offset of target from selected)*
 | 6    | _!mmm_     **set** rotation = atan(targetOffsetDown, targetOffsetRight) | *(calculate rotation from selected towards target)*
 | 7    | _!mmm_     **do** setattr(selectedToken, "rotation", -90 + rotation) | *(apply rotation to selected – assume token visually faces down, not right)*
 | 8    | _!mmm_ **end script**
@@ -885,6 +885,7 @@ If nothing is sent to chat at all after entering this command, MMM isn't install
 
 | Version | Date       | What's new?
 | ------- | ---------- | -----------
+| 1.20.0  | 2021-05-28 | Introduce `list[idx]` and `obj.prop` expression syntax
 | 1.19.0  | 2021-05-07 | Add `for` loop and improve `findattr()` to return lists
 | 1.18.0  | 2021-05-04 | Improve `highlight()` with `"info"` and `default` types
 | 1.17.0  | 2021-04-18 | Add `spawnfx()` to spawn visual effects

--- a/README.md
+++ b/README.md
@@ -592,6 +592,19 @@ This behavior comes in handy if you want to append or prepend items to a list va
 | 6    | _!mmm_     **chat:** I've got ${things} | ***Finn:*** I've got true, 456, something, 123
 | 7    | _!mmm_ **end script**
 
+You can access any specific item in a list by its index:
+
+| Line | Commands | What happens?
+| ---- | -------- | -------------
+| 1    | _!mmm_ **script**
+| 2    | _!mmm_     **set** things = "hat", "rope", "slingshot", "pie"
+| 3    | _!mmm_     **chat:** My first thing is a ${things[0]}. | ***Finn:*** My first thing is a hat.
+| 4    | _!mmm_     **chat:** Next, a ${things[1]}. | ***Finn:*** Next, a rope.
+| 5    | _!mmm_     **set** lastThing = things[-1] | *(use negative index to count from the back)*
+| 6    | _!mmm_     **chat:** Last but not least, a ${lastThing}. | ***Finn:*** Last but not least, a pie.
+| 7    | _!mmm_     **set** noThing = things[99] | *(index out of bounds simply returns nothing)*
+| 8    | _!mmm_ **end script**
+
 Of course, lists are most useful together with the [**for** loop](#mmm-for-variable-in-expression--end-for), which allows you to execute a block of code once for each list element in turn.
 
 

--- a/test/expressions.html
+++ b/test/expressions.html
@@ -158,6 +158,13 @@
                 { result: "9" },
             ],
             [
+                "1 + .5",
+                { result: "1.5" },
+            ],
+            [
+                "1 + .prop",
+                { error: "During parse, expected unary operator, or debug operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: 1 + ❌.prop" }            ],
+            [
                 "strlen('ookook')",
                 { result: "6" },
             ],

--- a/test/expressions.html
+++ b/test/expressions.html
@@ -23,123 +23,1053 @@
         body {
             font-family: Consolas, monospace;
             font-size: 9pt;
+            line-height: 13pt;
         }
 
-        div.expression
-        {
-            padding: 0.5em 1em 0.5em 1em;
+        div.expression {
+            padding: 0.5em 1em 1em 1em;
             border: 1px solid silver;
             margin-bottom: 1em;
             white-space: pre-wrap;
         }
 
-        span.success {
-            color: green;
+        div.results-success {
+            padding: 0.5em 1em;
+            border: 1px solid gray;
+            font-family: Calibri, sans-serif;
             font-weight: bold;
+            font-size: 12pt;
+            color: green;
+            background: #C0FFC0;
         }
 
-        span.type {
+        div.results-failure {
+            padding: 0.5em 1em;
+            border: 1px solid gray;
+            font-family: Calibri, sans-serif;
+            font-weight: bold;
+            font-size: 12pt;
+            color: red;
+            background: #FFC0C0;
+        }
+
+        table {
+            table-layout: fixed;
+        }
+
+        td.expression-header {
+            font-family: Calibri, sans-serif;
+            font-weight: bold;
+            font-size: 10pt;
+            padding-bottom: 0.5em;
+        }
+
+        td.lineno {
+            width: 3em;
+            color: gray;
+            font-family: Calibri, sans-serif;
+            text-align: right;
+            padding-right: 1em;
+        }
+
+        tr.token-header {
             color: gray;
             font-family: Calibri, sans-serif;
         }
 
-        span.error {
-            color: red;
+        tr.token-header td {
+            padding-top: 8pt;
+        }
+
+        tr.token td.token-source {
+            width: 20em;
+            border-top: 1px solid #E8E8E8;
+        }
+
+        tr.token td.token-type {
+            width: 20em;
             font-family: Calibri, sans-serif;
+            border-top: 1px solid #E8E8E8;
+        }
+
+        tr.token td.rule-name {
+            width: 20em;
+            font-family: Calibri, sans-serif;
+            border-top: 1px solid #E8E8E8;
+        }
+
+        tr.token td.evaluation {
+            padding-right: 1.5em;
+            font-family: Calibri, sans-serif;
+            border-top: 1px solid #E8E8E8;
+        }
+
+        tr.token td.evaluation.constant {
+            color: #C0C0C0;
+        }
+
+        td.output.debug {
+            font-family: Calibri, sans-serif;
+            white-space: pre-wrap;
+        }
+
+        td.output.error {
+            font-family: Calibri, sans-serif;
+            white-space: pre-wrap;
+        }
+
+        td.output.yield {
+            white-space: pre-wrap;
+        }
+
+        td.output.result {
+            white-space: pre-wrap;
+        }
+
+        tr.ok td.output {
+            color: green;
+        }
+
+        tr.unexpected td {
+            color: red;
+        }
+
+        tr.expected td {
+            background: yellow;
         }
     </style>
 </head>
 <body>
     <script>
-        var variables =
+        let includedExpressionSources = [];
+
+        let expressionSources =
+        [
+            [
+                "version",
+                { result: MychExpression.literal(MMM_VERSION) },
+            ],
+            [
+                "1 + 2 * 3",
+                { result: "7" },
+            ],
+            [
+                "(1 + 2) * 3",
+                { result: "9" },
+            ],
+            [
+                "strlen('ookook')",
+                { result: "6" },
+            ],
+            [
+                "(1 == 1)",
+                { result: "true" },
+            ],
+            [
+                "(1 == 2)",
+                { result: "false" },
+            ],
+            [
+                "(1 == 1) and (2 != 3)",
+                { result: "true" },
+            ],
+            [
+                "1 + ()",
+                { error: "During parse, expected unary operator, or debug operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: 1 + (❌)" },
+            ],
+            [
+                "1 * ()",
+                { error: "During parse, expected unary operator, or debug operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: 1 * (❌)" },
+            ],
+            [
+                "3 * (() + 2)",
+                { error: "During parse, expected unary operator, or debug operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: 3 * ((❌) + 2)" },
+            ],
+            [
+                "2 ** 8",
+                { result: "256" },
+            ],
+            [
+                "2 ** 2 ** 3",
+                { result: "256" },
+            ],
+            [
+                "list12, list345",
+                { result: "1, 2, 3, 4, 5" },
+            ],
+            [
+                "list12[]",
+                { error: "During parse, expected unary operator, or debug operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: list12[❌]" },
+            ],
+            [
+                "list12[0] + list345[1 + 1]",
+                { result: "6" },
+            ],
+            [
+                "list12[0][1]",
+                { error: "During parse, expected binary operator, or property lookup, or end of expression in expression: list12[0]❌[1]" },
+            ],
+            [
+                "list12[0)",
+                { error: "During parse, expected binary operator, or property lookup, or closing bracket in expression: list12[0❌)" },
+            ],
+            [
+                "(11, 22, 33)[2]",
+                { result: "33" },
+            ],
+            [
+                "args()",
+                { result: "" },
+            ],
+            [
+                "args(())",
+                { error: "During parse, expected unary operator, or debug operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: args((❌))" },
+            ],
+            [
+                "args(1)",
+                { result: "1" },
+            ],
+            [
+                "args(1, 'two', 3, 'four')",
+                { result: "1, \"two\", 3, \"four\"" },
+            ],
+            [
+                "args(list12, list345)",
+                { result: "1, 2, 3, 4, 5" },
+            ],
+            [
+                "args((1, 'two'), (3, 'four'))",
+                { result: "1, \"two\", 3, \"four\"" },
+            ],
+            [
+                "argnum()",
+                { result: "0" },
+            ],
+            [
+                "argnum(1, 2, 3, 4)",
+                { result: "4" },
+            ],
+            [
+                "argnum(1, (2, 3, 4))",
+                { result: "4" },
+            ],
+            [
+                "argnum((1, 2, 3), 4)",
+                { result: "4" },
+            ],
+            [
+                "argnum((1, 2), (3, 4))",
+                { result: "4" },
+            ],
+            [
+                "argnum(list345)",
+                { result: "1" },
+            ],
+            [
+                "argnum(1, list345)",
+                { result: "2" },
+            ],
+            [
+                "argnum(list345, 2)",
+                { result: "2" },
+            ],
+            [
+                "argnum(1, list345, 2)",
+                { result: "3" },
+            ],
+            [
+                "listnum(arg1(1, list345, 2))",
+                { result: "3" },
+            ],
+            [
+                "argnum(undef)",
+                { result: "1" },
+            ],
+            [
+                "argnum(1, undef)",
+                { result: "2" },
+            ],
+            [
+                "argnum(undef, 2)",
+                { result: "2" },
+            ],
+            [
+                "argnum(1, undef, 2)",
+                { result: "3" },
+            ],
+            [
+                "argnum(denied)",
+                { result: "1" },
+            ],
+            [
+                "argnum(1, denied)",
+                { result: "2" },
+            ],
+            [
+                "argnum(denied, 2)",
+                { result: "2" },
+            ],
+            [
+                "argnum(1, denied, 2)",
+                { result: "3" },
+            ],
+            [
+                "isdenied(arg1(1, denied, 2))",
+                { result: "true" },
+            ],
+            [
+                "argnum(unknown)",
+                { result: "1" },
+            ],
+            [
+                "argnum(1, unknown)",
+                { result: "2" },
+            ],
+            [
+                "argnum(unknown, 2)",
+                { result: "2" },
+            ],
+            [
+                "argnum(1, unknown, 2)",
+                { result: "3" },
+            ],
+            [
+                "isunknown(arg1(1, unknown, 2))",
+                { result: "true" },
+            ],
+            [
+                "argnum(default)",
+                { result: "1" },
+            ],
+            [
+                "argnum(1, default)",
+                { result: "2" },
+            ],
+            [
+                "argnum(default, 2)",
+                { result: "2" },
+            ],
+            [
+                "argnum(1, default, 2)",
+                { result: "3" },
+            ],
+            [
+                "isdefault(arg1(1, default, 2))",
+                { result: "true" },
+            ],
+            [
+                "getattr('Char1', 'HP')",
+                { result: "\"15\"" },
+            ],
+            [
+                "async('background process', 999)",
+                { yield: "\"background process\"" },
+                { result: "999" },
+            ],
+            [
+                "async('background process', 999) + 1",
+                { yield: "\"background process\"" },
+                { result: "1000" },
+            ],
+            [
+                "--+-+-+-strlen('ookook')",
+                { result: "-6" },
+            ],
+            [
+                "strlen(1 + 10 + 90)",
+                { result: "3" },
+            ],
+            [
+                "structABC.propA & structABC.propB",
+                { result: "\"A!B!\"" },
+            ],
+            [
+                "structABC.('prop' & 'A')",
+                { result: "\"A!\"" },
+            ],
+            [
+                "structABC.unknownProp",
+                { result: "undef" },
+            ],
+            [
+                "noStruct.someProp",
+                { result: "\"(unknown property 'someProp')\"" },
+            ],
+            [
+                "'literal string'.someProp",
+                { result: "\"(unknown property 'someProp')\"" },
+            ],
+            [
+                "6+++++7",
+                { result: "13" },
+            ],
+            [
+                "6++-++7",
+                { result: "-1" },
+            ],
+            [
+                "(((1)",
+                { error: "During parse, expected binary operator, or property lookup, or opening bracket (for array subscript), or closing parenthesis in expression: (((1)❌" },
+            ],
+            [
+                "(((1))",
+                { error: "During parse, expected binary operator, or property lookup, or opening bracket (for array subscript), or closing parenthesis in expression: (((1))❌" },
+            ],
+            [
+                "(((1)))",
+                { result: "1" },
+            ],
+            [
+                "(((1))))",
+                { error: "During parse, expected binary operator, or property lookup, or opening bracket (for array subscript), or end of expression in expression: (((1)))❌)" },
+            ],
+            [
+                "(((1)))]",
+                { error: "During parse, expected binary operator, or property lookup, or opening bracket (for array subscript), or end of expression in expression: (((1)))❌]" },
+            ],
+            [
+                "(3 + (2 + (1) *",
+                { error: "During parse, expected unary operator, or debug operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: (3 + (2 + (1) *❌" },
+            ],
+            [
+                "(1 + 2 * 3 + 4 ** 5) - foo / bar + (6 + 7, (8 + 9) * 10 - strlen('foo \\'bar\\' baz \\\\quux'))",
+                { result: "1181.7302631578948" },
+            ],
+            [
+                "(1 + 2 * 3 + 4 ** 5) - foo! / bar(6 + 7, (8 + 9) * 10)",
+                { error: "During parse, syntax error in expression: (1 + 2 * 3 + 4 ** 5) - foo❌! / bar(6 + 7, (8 + 9) * 10)" },
+            ],
+            [
+                "(1 + 2 * 3 + 4 ** 5) - foo / bar(6 + 7)",
+                { error: "During evaluate, invalid function in expression: (1 + 2 * 3 + 4 ** 5) - foo / bar❌(6 + 7)" },
+            ],
+            [
+                "(1 + 2 * 3 + 4 ** 5) - foo / quux(6 + 7)",
+                { error: "During evaluate, unknown function in expression: (1 + 2 * 3 + 4 ** 5) - foo / quux❌(6 + 7)" },
+            ],
+            [
+                ") + 123",
+                { error: "During parse, expected unary operator, or debug operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: ❌) + 123" },
+            ],
+            [
+                "* 456",
+                { error: "During parse, expected unary operator, or debug operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: ❌* 456" },
+            ],
+            [
+                "1 + ?",
+                { error: "During parse, expected unary operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: 1 + ?❌" },
+            ],
+            [
+                "1 + ? ? 2",
+                { error: "During parse, expected unary operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: 1 + ? ❌? 2" },
+            ],
+            [
+                "1 + ???? 2",
+                { error: "During parse, expected unary operator, or literal value, or variable or function name, or opening parenthesis (for expression grouping) in expression: 1 + ???❌? 2" },
+            ],
+            [
+                "1 + ? 2 * 3 + 4",
+                { debug: "❰2❱ ← 1 + ? ❰2❱ * 3 + 4" },
+                { result: "11" },
+            ],
+            [
+                "1 + ?? 2 * 3 + 4",
+                { debug: "❰6❱ ← 1 + ?? ❰2 * 3❱ + 4" },
+                { result: "11" },
+            ],
+            [
+                "1 + ??? 2 * 3 + 4",
+                { debug: "❰6❱ ← 1 + ??? ❰2 * 3❱ + 4" },
+                { result: "11" },
+            ],
+            [
+                "1 + ?(2 * 3) + 4",
+                { debug: "❰6❱ ← 1 + ?❰(2 * 3)❱ + 4" },
+                { result: "11" },
+            ],
+            [
+                "1 + ?((2 * 3)) + 4",
+                { debug: "❰6❱ ← 1 + ?❰((2 * 3))❱ + 4" },
+                { result: "11" },
+            ],
+            [
+                "1 + ?(2 * 3 + 4)",
+                { debug: "❰10❱ ← 1 + ?❰(2 * 3 + 4)❱" },
+                { result: "11" },
+            ],
+            [
+                "1 + ?((2 * 3 + 4))",
+                { debug: "❰10❱ ← 1 + ?❰((2 * 3 + 4))❱" },
+                { result: "11" },
+            ],
+            [
+                "1 + ?(2 * 3 + ? 4)",
+                { debug: "❰4❱ ← 1 + ?(2 * 3 + ? ❰4❱)" },
+                { debug: "❰10❱ ← 1 + ?❰(2 * 3 + ? 4)❱" },
+                { result: "11" },
+            ],
+            [
+                "1 + ?getattr('Dummy', 'HP')",
+                { debug: "❰\"15\"❱ ← 1 + ?❰getattr('Dummy', 'HP')❱" },
+                { result: "16" },
+            ],
+            [
+                "?('foo' & 123 & 'bar')",
+                { debug: "❰\"foo123bar\"❱ ← ?❰('foo' & 123 & 'bar')❱" },
+                { result: "\"foo123bar\"" },
+            ],
+            [
+                "1 + ? 2**3 * 4 <= 5",
+                { debug: "❰2❱ ← 1 + ? ❰2❱**3 * 4 <= 5" },
+                { result: "false" },
+            ],
+            [
+                "1 + ?? 2**3 * 4 <= 5",
+                { debug: "❰32❱ ← 1 + ?? ❰2**3 * 4❱ <= 5" },
+                { result: "false" },
+            ],
+            [
+                "1 + ??? 2**3 * 4 <= 5",
+                { debug: "❰32❱ ← 1 + ??? ❰2**3 * 4❱ <= 5" },
+                { result: "false" },
+            ],
+            [
+                "? 2**3 * 4 <= 5",
+                { debug: "❰2❱ ← ? ❰2❱**3 * 4 <= 5" },
+                { result: "false" },
+            ],
+            [
+                "?? 2**3 * 4 <= 5",
+                { debug: "❰32❱ ← ?? ❰2**3 * 4❱ <= 5" },
+                { result: "false" },
+            ],
+            [
+                "??? 2**3 * 4 <= 5",
+                { debug: "❰false❱ ← ??? ❰2**3 * 4 <= 5❱" },
+                { result: "false" },
+            ],
+            [
+                "? default + 123",
+                { debug: "❰undef❱ ← ? ❰default❱ + 123" },
+                { result: "123" },
+            ],
+            [
+                "? denied + 123",
+                { debug: "❰undef❱ ← ? ❰denied❱ + 123" },
+                { result: "123" },
+            ],
+            [
+                "? unknown + 123",
+                { debug: "❰undef❱ ← ? ❰unknown❱ + 123" },
+                { result: "123" },
+            ],
+            [
+                "true",
+                { result: "true" },
+            ],
+            [
+                "false",
+                { result: "false" },
+            ],
+            [
+                "11 % 8",
+                { result: "3" },
+            ],
+            [
+                "-11 % 8",
+                { result: "5" },
+            ],
+            [
+                "11 % -8",
+                { result: "-5" },
+            ],
+            [
+                "-11 % -8",
+                { result: "-3" },
+            ],
+            [
+                "min()",
+                { result: "undef" },
+            ],
+            [
+                "min(+123, undef)",
+                { result: "123" },
+            ],
+            [
+                "min(-456, undef)",
+                { result: "-456" },
+            ],
+            [
+                "min(5, undefined, 'moo', 999, 2, -3.14)",
+                { result: "-3.14" },
+            ],
+            [
+                "max()",
+                { result: "undef" },
+            ],
+            [
+                "max(5, undefined, 'moo', 999, 2, -3.14)",
+                { result: "999" },
+            ],
+            [
+                "floor(-1.2)",
+                { result: "-2" },
+            ],
+            [
+                "floor(-1.5)",
+                { result: "-2" },
+            ],
+            [
+                "floor(-1.7)",
+                { result: "-2" },
+            ],
+            [
+                "floor(1.2)",
+                { result: "1" },
+            ],
+            [
+                "floor(1.5)",
+                { result: "1" },
+            ],
+            [
+                "floor(1.7)",
+                { result: "1" },
+            ],
+            [
+                "round(-1.2)",
+                { result: "-1" },
+            ],
+            [
+                "round(-1.5)",
+                { result: "-1" },
+            ],
+            [
+                "round(-1.7)",
+                { result: "-2" },
+            ],
+            [
+                "round(1.2)",
+                { result: "1" },
+            ],
+            [
+                "round(1.5)",
+                { result: "2" },
+            ],
+            [
+                "round(1.7)",
+                { result: "2" },
+            ],
+            [
+                "ceil(-1.2)",
+                { result: "-1" },
+            ],
+            [
+                "ceil(-1.5)",
+                { result: "-1" },
+            ],
+            [
+                "ceil(-1.7)",
+                { result: "-1" },
+            ],
+            [
+                "ceil(1.2)",
+                { result: "2" },
+            ],
+            [
+                "ceil(1.5)",
+                { result: "2" },
+            ],
+            [
+                "ceil(1.7)",
+                { result: "2" },
+            ],
+            [
+                "abs(-1.5)",
+                { result: "1.5" },
+            ],
+            [
+                "abs(1.5)",
+                { result: "1.5" },
+            ],
+        ];
+
+        let outputs = [];
+
+        MychScriptContext.prototype.strlen = function(value)
+        {
+            return MychExpression.coerceString(value).length;
+        }
+
+        MychScriptContext.prototype.args = function(...values)
+        {
+            return values;
+        }
+
+        MychScriptContext.prototype.argnum = function(...args)
+        {
+            return args.length;
+        }
+
+        MychScriptContext.prototype.arg0 = function(...args)
+        {
+            return args[0];
+        }
+
+        MychScriptContext.prototype.arg1 = function(...args)
+        {
+            return args[1];
+        }
+
+        MychScriptContext.prototype.arg2 = function(...args)
+        {
+            return args[2];
+        }
+
+        MychScriptContext.prototype.listnum = function(list)
+        {
+            if (list instanceof MychExpressionArgs)
+            {
+                console.log("Require list, got", list);
+                return new MychScriptContext.Unknown("Require list, got args");
+            }
+
+            if (Array.isArray(list))
+            {
+                return list.length;
+            }
+            
+            console.log("Require list, got", list);
+            return new MychScriptContext.Unknown("Require list, got " + typeof(list));
+        }
+
+        MychScriptContext.prototype.getattr = function(characterName, attributeName)
+        {
+            return "15";
+        }
+
+        MychScriptContext.prototype.async = function*(intermediate, result)
+        {
+            yield intermediate;
+            return result;
+        }
+
+        MychScriptContext.prototype.getprop = function(struct, key)
+        {
+            return "(unknown property '" + key + "')";
+        }
+
+        MychScriptContext.prototype.$debugSendExpression = function(result, source, resultSourceBegin = 0, resultSourceEnd = source.length)
+        {
+            let markedSourceBefore = source.substring(0, resultSourceBegin);
+            let markedSourceBetween = source.substring(resultSourceBegin, resultSourceEnd);
+            let markedSourceAfter = source.substring(resultSourceEnd);
+
+            let debugResult = "\u2770" + MychExpression.literal(result) + "\u2771";
+            let debugSource = markedSourceBefore + "\u2770" + markedSourceBetween + "\u2771" + markedSourceAfter;
+
+            outputs.push(
+            {
+                type: "debug",
+                text: debugResult + " \u2190 " + debugSource,
+            });
+        }
+
+        let variables =
         {
             foo: 123,
             bar: 456,
             
-            len: function(value)
-            {
-                return MychExpression.coerceString(value).length;
-            },
+            list12: [1, 2],
+            list345: [3, 4, 5],
 
-            count: function(values)
+            structABC:
             {
-                return arguments.length;
-            },
+                getProperty: function(key) { return this[key] },
 
-            list: function(values)
-            {
-                var elements = [];
-                for (var i = 0; i < arguments.length; ++i)
-                {
-                    elements.push("<" + arguments[i] + ">");
-                }
-                return elements.join("|");
+                propA: "A!",
+                propB: "B!",
+                propC: "C!",
             },
-
-            getattr: function(characterName, attributeName)
-            {
-                return "15";
-            },
-
-            array1: [1, 2],
-            array2: [3, 4, 5],
         };
 
-        var expressionSources =
-        [
-            "version",
-            "1+2*3",
-            "(1+2)*3",
-            "len('ookook')",
-            "(1==1)",
-            "(1==2)",
-            "(1==1) and (2!=3)",
-            "1+()",
-            "1*()",
-            "3*(()+2)",
-            "2**8",
-            "array1,array2",
-            "list()",
-            "list(())",
-            "list(1)",
-            "list(1,'two',3,'four')",
-            "list(array1, array2)",
-            "list((1,'two'),(3,'four'))",
-            "getattr('Char1', 'AP')",
-            "--+-+-+-len('ookook')",
-            "len(1+10+90)",
-            "6+++++7",
-            "6++-++7",
-            "(((1))",
-            "(((1)))",
-            "(((1))))",
-            "(3+(2+(1)*",
-            "(1+2*3+4**5)-foo/bar+(6+7,(8+9)*10-len('foo \\'bar\\' baz \\\\quux'))",
-            "(1+2*3+4**5)-foo!/bar(6+7,(8+9)*10)",
-            "(1+2*3+4**5)-foo/bar(6+7)",
-            ")+123",
-            "*456",
-        ];
+        let numTestsRun = 0;
+        let numTestsSuccessful = 0;
+        let testsFailed = [];
 
-        for (expressionSource of expressionSources)
+        for (let expressionSourceIndex = 0; expressionSourceIndex < expressionSources.length; ++expressionSourceIndex)
         {
+            if (includedExpressionSources.length > 0 && !includedExpressionSources.includes(expressionSourceIndex))
+            {
+                continue;
+            }
+
+            let testSuccessful = true;
+
+            let expressionSource = expressionSources[expressionSourceIndex][0];
+            let expectedOutputs = expressionSources[expressionSourceIndex].slice(1);
+            
             document.write("<div class='expression'>");
+            document.write("<table>");
+            document.write("<tr><td></td><td class='expression-header' colspan='4'>test expression " + expressionSourceIndex + "</td></tr>");
+
+            document.write("<tr>");
+            document.write("<td class='lineno'>source</td>")
+            document.write("<td colspan='4'>" + escapeHTML(expressionSource) + "</td>");
+            document.write("</tr>");
+
+            let expression = new MychExpression();
             
             try
             {
-                var expression = new MychExpression(expressionSource);
+                expression.parse(expressionSource, new MychScriptContext());
 
-                var result = expression.evaluate(variables, new MychScriptContext()).next().value;
-                var resultType = (result instanceof Object ? result.constructor.name : typeof(result));
+                let resultGenerator = expression.evaluate(variables);
+                let resultContainer;
 
-                document.write(escapeHTML(expressionSource) + " = <span class='success'>" + escapeHTML(JSON.stringify(result)) + "</span> <span class='type'>[" + escapeHTML(resultType) + "]</span>");
+                while (!(resultContainer = resultGenerator.next()).done)
+                {
+                    outputs.push(
+                    {
+                        type: "yield",
+                        text: MychExpression.literal(resultContainer.value),
+                    });
+                }
+
+                outputs.push(
+                {
+                    type: "result",
+                    text: MychExpression.literal(resultContainer.value),
+                });
+
+                if (expression.isConstant())
+                {
+                    let constantResult = expression.evaluateConstant();
+
+                    if (resultContainer.value !== constantResult)
+                    {
+                        console.log("result:", resultContainer.value, "constant:", constantResult);
+                        throw "Constant result not equal to variable result";
+                    }
+                }
             }
             catch (exception)
             {
                 console.log(exception);
-                document.write(escapeHTML(expressionSource) + " = <span class='error'>" + escapeHTML(exception) + "</span>");
+
+                outputs.push(
+                {
+                    type: "error",
+                    text: String(exception),
+                });
             }
 
+            while (outputs.length > 0)
+            {
+                let output = outputs.shift();
+
+                let expectedOutput = expectedOutputs.shift();
+                let expectedOutputSatisfied = false;
+                let expectedOutputType;
+                let expectedOutputText;
+
+                let receivedOutputType = output.type;
+                let receivedOutputText = output.text;
+
+                if (expectedOutput)
+                {
+                    [expectedOutputType, expectedOutputText] = Object.entries(expectedOutput)[0];
+                    expectedOutputSatisfied = (receivedOutputType == expectedOutputType && receivedOutputText == expectedOutputText);
+                }
+
+                if (expectedOutputSatisfied)
+                {
+                    document.write("<tr class='ok'>");
+                    document.write("<td class='lineno'>" + receivedOutputType + "</td>")
+                    document.write("<td class='output " + receivedOutputType + "' colspan='4'>" + escapeHTML(receivedOutputText) + "</td>");
+                    document.write("</tr>");
+                }
+                else
+                {
+                    testSuccessful = false;
+
+                    document.write("<tr class='unexpected'>");
+                    document.write("<td class='lineno'>" + receivedOutputType + "</td>")
+                    document.write("<td class='output " + receivedOutputType + "' colspan='4'>" + escapeHTML(receivedOutputText) + "</td>");
+                    document.write("</tr>");
+
+                    console.log("received:", JSON.stringify({ [receivedOutputType]: receivedOutputText }));
+
+                    if (expectedOutput)
+                    {
+                        document.write("<tr class='expected'>");
+                        document.write("<td class='lineno'>" + expectedOutputType + "</td>")
+                        document.write("<td class='output " + expectedOutputType + "' colspan='4'>" + escapeHTML(expectedOutputText) + "</td>");
+                        document.write("</tr>");
+
+                        console.log("expected:", JSON.stringify({ [expectedOutputType]: expectedOutputText }));
+                    }
+                }
+            }
+
+            for (let expectedOutput of expectedOutputs)
+            {
+                testSuccessful = false;
+
+                [expectedOutputType, expectedOutputText] = Object.entries(expectedOutput)[0];
+
+                document.write("<tr class='expected'>");
+                document.write("<td class='lineno'>" + expectedOutputType + "</td>")
+                document.write("<td class='output " + expectedOutputType + "' colspan='4'>" + escapeHTML(expectedOutputText) + "</td>");
+                document.write("</tr>");
+
+                console.log("expected:", JSON.stringify({ [expectedOutputType]: expectedOutputText }));
+            }
+
+            expectedOutputs.length = 0;
+
+            let dependencyEntriesPerRow = expression.tokens.map(token => []);
+            let numDependencyLevels = 0;
+            let numDependencyEvaluators = 0;
+            let numDependencyEvaluatorsToLevel = [0];
+
+            if (expression.evaluator)
+            {
+                let evaluators = expression.evaluator.argEvaluators ? [expression.evaluator] : [];
+
+                while (evaluators.length > 0)
+                {
+                    let nextEvaluators = [];
+
+                    for (let evaluator of evaluators)
+                    {
+                        for (let argIndex = 0; argIndex < evaluator.argEvaluators.length; ++argIndex)
+                        {
+                            let argEvaluator = evaluator.argEvaluators[argIndex];
+
+                            if (argEvaluator == undefined)
+                            {
+                                continue;
+                            }
+
+                            for (let tokenIndex = 0; tokenIndex < expression.tokens.length; ++tokenIndex)
+                            {
+                                let token = expression.tokens[tokenIndex];
+
+                                if (token.offset < argEvaluator.sourceOffset || token.offset + token.length > argEvaluator.sourceOffset + argEvaluator.sourceLength)
+                                {
+                                    continue;
+                                }
+
+                                dependencyEntriesPerRow[tokenIndex][numDependencyLevels] =
+                                {
+                                    evaluatorIndex: numDependencyEvaluators,
+                                    argIndex: argIndex,
+                                    argEvaluator: argEvaluator,
+                                };
+                            }
+
+                            nextEvaluators.push(argEvaluator);
+                        }
+
+                        numDependencyEvaluators += 1;
+                    }
+
+                    evaluators = nextEvaluators.filter(evaluator => evaluator.argEvaluators);
+
+                    numDependencyLevels += 1;
+                    numDependencyEvaluatorsToLevel[numDependencyLevels] = numDependencyEvaluators;
+                }
+
+                dependencyEntriesPerRow[dependencyEntriesPerRow.length - 1] = [];
+            }
+
+            document.write("<tr class='token-header'>");
+            document.write("<td></td>")
+            document.write("<td>token</td>");
+            document.write("<td>type</td>");
+            document.write("<td>rule</td>");
+
+            if (numDependencyLevels == 0)
+            {
+                document.write("<td>evaluation</td>");
+            }
+            else
+            {
+                let colspan = numDependencyLevels;
+                document.write("<td colspan='" + colspan + "'>evaluation</td>");
+            }
+
+            document.write("</tr>");
+
+            for (let tokenIndex = 0; tokenIndex < expression.tokens.length; ++tokenIndex)
+            {
+                let token = expression.tokens[tokenIndex];
+
+                document.write("<tr class='token'>");
+                document.write("<td class='lineno'>" + tokenIndex + "</td>")
+                document.write("<td class='token-source'>" + escapeHTML(expression.source.substr(token.offset, token.length)) + "</td>")
+                document.write("<td class='token-type'>" + escapeHTML(token.type) + "</td>")
+                document.write("<td class='rule-name'>" + escapeHTML(token.ruleName || "") + "</td>")
+
+                let dependencyEntriesForRow = dependencyEntriesPerRow[tokenIndex];
+
+                if (dependencyEntriesForRow.length == 0)
+                {
+                    let colspan = numDependencyLevels;
+                    document.write("<td colspan='" + colspan + "' class='evaluation'></td>");
+                }
+                else
+                {
+                    for (let dependencyLevel = 0; dependencyLevel < dependencyEntriesForRow.length; ++dependencyLevel)
+                    {
+                        let dependencyEntry = dependencyEntriesForRow[dependencyLevel];
+
+                        let dependencyDescriptionOrder = 1 + (numDependencyEvaluators - numDependencyEvaluatorsToLevel[dependencyLevel + 1]) + dependencyEntry.evaluatorIndex - numDependencyEvaluatorsToLevel[dependencyLevel];
+                        let dependencyDescriptionArgument = String.fromCharCode(dependencyEntry.argIndex + "A".charCodeAt(0));
+                        let dependencyDescription = dependencyDescriptionOrder + dependencyDescriptionArgument;
+
+                        let evaluationVariabilityClass = dependencyEntry.argEvaluator.isConstant ? "constant" : "variable";
+
+                        if (dependencyLevel < dependencyEntriesForRow.length - 1)
+                        {
+                            document.write("<td class='evaluation " + evaluationVariabilityClass + "'>");
+                        }
+                        else
+                        {
+                            let colspan = numDependencyLevels - (dependencyEntriesForRow.length - 1);
+                            document.write("<td class='evaluation " + evaluationVariabilityClass + "' colspan='" + colspan + "'>");
+                        }
+
+                        document.write(escapeHTML(dependencyDescription));
+                        document.write("</td>");
+                    }
+                }
+
+                document.write("</tr>");
+            }
+
+            document.write("</table>");
+            document.write("</div>");
+
+            numTestsRun += 1;
+            numTestsSuccessful += (testSuccessful ? 1 : 0);
+
+            if (!testSuccessful)
+            {
+                testsFailed.push(expressionSourceIndex);
+            }
+        }
+
+        if (numTestsSuccessful == numTestsRun)
+        {
+            document.write("<div class='results-success'>");
+            document.write("Success: Evaluated " + numTestsRun + " test expressions, all successful.");
+            document.write("</div>");
+        }
+        else
+        {
+            document.write("<div class='results-failure'>");
+            document.write("Failed: Evaluated " + numTestsRun + " test expressions, " + (numTestsRun - numTestsSuccessful) + " failed (expression index " + testsFailed.join(", ") + ")");
             document.write("</div>");
         }
     </script>

--- a/test/scripts.html
+++ b/test/scripts.html
@@ -188,6 +188,10 @@
                 { error: "During parse, syntax error in script: set incorrectAssignmentOperator ❌:= 123 + 456" },
             ],
             [
+                "!mmm chat: ${syntax error}",
+                { error: "During parse, expected binary operator, or property lookup, or opening parenthesis (for function arguments), or opening bracket (for array subscript), or end of expression in expression in template in script: chat: ${syntax ❌error}" },
+            ],
+            [
                 "!mmm do chat('correct')",
                 { chat: "correct" },
             ],

--- a/test/scripts.html
+++ b/test/scripts.html
@@ -197,35 +197,43 @@
             ],
             [
                 "!mmm do chat 'missing parentheses'",
-                { error: "During execute, any literal not expected here (expected opening parenthesis) in expression in script: !mmm do chat ❌'missing parentheses'" }
+                { error: "During parse, expected binary operator, or property lookup, or opening parenthesis (for function arguments), or opening bracket (for array subscript), or end of expression in expression in script: do chat ❌'missing parentheses'" }
             ],
             [
                 "!mmm     unknown command",
                 { error: "During parse, unknown command in script:     ❌unknown command" },
             ],
             [
-                "!mmm chat: Hello World! Meaning of life: ${6*7}, current AP: ${getattr('Dummy', 'AP')}",
-                { chat: "Hello World! Meaning of life: 42, current AP: 20" },
+                "!mmm chat: Hello World! Meaning of life: ${6*7}, current HP: ${getattr('Finn', 'HP')}",
+                { chat: "Hello World! Meaning of life: 42, current HP: 20" },
+            ],
+            [
+                "!mmm chat: Finn's name: ${'Finn'.name}, HP: ${'Finn'.HP}, max: ${'Finn'.HP.max}",
+                { chat: "Finn's name: Finn MacRathgar, HP: 20, max: 30" },
+            ],
+            [
+                "!mmm chat: Finn's brother's name: ${'Finn'.brother.name}, HP: ${'Finn'.brother.HP}, max: ${'Finn'.brother.HP.max}",
+                { chat: "Finn's brother's name: <span class=\"mmm-unknown showtip tipsy-n-right\" title=\"Unknown attribute: brother\" style=\"background: darkorange; border: 2px solid darkorange; color: white; font-weight: bold; cursor: help\">unknown</span>, HP: <span class=\"mmm-unknown showtip tipsy-n-right\" title=\"Unknown attribute: brother\" style=\"background: darkorange; border: 2px solid darkorange; color: white; font-weight: bold; cursor: help\">unknown</span>, max: <span class=\"mmm-unknown showtip tipsy-n-right\" title=\"Unknown attribute: brother\" style=\"background: darkorange; border: 2px solid darkorange; color: white; font-weight: bold; cursor: help\">unknown</span>" },
+            ],
+            [
+                "!mmm chat: Finn's cousin's name: ${'Finn'.cousin.name}, HP: ${'Finn'.cousin.HP}, max: ${'Finn'.cousin.HP.max}",
+                { chat: "Finn's cousin's name: Yorrick MacRathgar, HP: 18, max: 28" },
             ],
             [
                 "!mmm chat: this <${undefinedValue}> should be empty",
                 { chat: "this <> should be empty" },
             ],
             [
-                "!mmm chat:  11 %  8 = ${ 11 %  8}", { chat:  "11 %  8 = 3" },
-                "!mmm chat: -11 %  8 = ${-11 %  8}", { chat: "-11 %  8 = 5" },
-                "!mmm chat:  11 % -8 = ${ 11 % -8}", { chat:  "11 % -8 = -5" },
-                "!mmm chat: -11 % -8 = ${-11 % -8}", { chat: "-11 % -8 = -3" },
+                "!mmm chat: this is \\${escaped} but ${'this is not'}",
+                { chat: "this is \${escaped} but this is not" },
             ],
             [
-                "!mmm chat: floor(.) = (-1.2) = ${floor(-1.2)}, (-1.5) = ${floor(-1.5)}, (-1.7) = ${floor(-1.7)}, (1.2) = ${floor(1.2)}, (1.5) = ${floor(1.5)}, (1.7) = ${floor(1.7)}",
-                { chat: "floor(.) = (-1.2) = -2, (-1.5) = -2, (-1.7) = -2, (1.2) = 1, (1.5) = 1, (1.7) = 1" },
-                "!mmm chat: round(.) = (-1.2) = ${round(-1.2)}, (-1.5) = ${round(-1.5)}, (-1.7) = ${round(-1.7)}, (1.2) = ${round(1.2)}, (1.5) = ${round(1.5)}, (1.7) = ${round(1.7)}",
-                { chat: "round(.) = (-1.2) = -1, (-1.5) = -1, (-1.7) = -2, (1.2) = 1, (1.5) = 2, (1.7) = 2" },
-                "!mmm chat: ceil(.) = (-1.2) = ${ceil(-1.2)}, (-1.5) = ${ceil(-1.5)}, (-1.7) = ${ceil(-1.7)}, (1.2) = ${ceil(1.2)}, (1.5) = ${ceil(1.5)}, (1.7) = ${ceil(1.7)}",
-                { chat: "ceil(.) = (-1.2) = -1, (-1.5) = -1, (-1.7) = -1, (1.2) = 2, (1.5) = 2, (1.7) = 2" },
-                "!mmm chat: abs(.) = (-1.2) = ${abs(-1.2)}, (-1.5) = ${abs(-1.5)}, (-1.7) = ${abs(-1.7)}, (1.2) = ${abs(1.2)}, (1.5) = ${abs(1.5)}, (1.7) = ${abs(1.7)}",
-                { chat: "abs(.) = (-1.2) = 1.2, (-1.5) = 1.5, (-1.7) = 1.7, (1.2) = 1.2, (1.5) = 1.5, (1.7) = 1.7" },
+                "!mmm chat: this is \\\\${'not escaped'}",
+                { chat: "this is \\not escaped" },
+            ],
+            [
+                "!mmm chat: this is \\$[escaped]{escaped} but ${'this is not'}",
+                { chat: "this is \$[escaped]{escaped} but this is not" },
             ],
             [
                 "!mmm if undefinedVariable",
@@ -260,12 +268,6 @@
                 { chat: "correct" },
             ],
             [
-                "!mmm chat: min() = <${min()}>, min(+123, undef) = ${min(+123, undef)}, min(.) = ${min(5, undefined, 'moo', 999, 2, -3.14)}",
-                { chat: "min() = <>, min(+123, undef) = 123, min(.) = -3.14" },
-                "!mmm chat: max() = <${max()}>, min(-456, undef) = ${min(-456, undef)}, max(.) = ${max(5, undefined, 'moo', 999, 2, -3.14)}",
-                { chat: "max() = <>, min(-456, undef) = -456, max(.) = 999" },
-            ],
-            [
                 "!mmm chat: isdefault(default) = ${isdefault(default)}",
                 { chat: "isdefault(default) = true" },
                 "!mmm chat: isdenied(denied) = ${isdenied(denied)}",
@@ -284,69 +286,14 @@
                 { chat: "getreason(unknown) = " },
             ],
             [
-                "!mmm chat: ${1 + ?}",
-                { error: "During execute, expected unary operator, any literal, any identifier, opening parenthesis in expression in template in script: !mmm chat: ${1 + ?❌}" },
-                "!mmm chat: ${1 + ? ? 2}",
-                { error: "During execute, any debug not expected here (expected unary operator, any literal, any identifier, opening parenthesis) in expression in template in script: !mmm chat: ${1 + ? ❌? 2}" },
-                "!mmm chat: ${1 + ???? 2}",
-                { error: "During execute, any debug not expected here (expected unary operator, any literal, any identifier, opening parenthesis) in expression in template in script: !mmm chat: ${1 + ???❌? 2}" },
-                "!mmm chat: ${1 + ? 2 * 3 + 4}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>2</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>? 2</span> * 3 + 4" },
-                { chat: "11" },
-                "!mmm chat: ${1 + ?? 2 * 3 + 4}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>6</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?? 2 * 3</span> + 4" },
-                { chat: "11" },
-                "!mmm chat: ${1 + ??? 2 * 3 + 4}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>6</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>??? 2 * 3</span> + 4" },
-                { chat: "11" },
-                "!mmm chat: ${1 + ?(2 * 3) + 4}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>6</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?(2 * 3)</span> + 4" },
-                { chat: "11" },
-                "!mmm chat: ${1 + ?((2 * 3)) + 4}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>6</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?((2 * 3))</span> + 4" },
-                { chat: "11" },
-                "!mmm chat: ${1 + ?(2 * 3 + 4)}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>10</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?(2 * 3 + 4)</span>" },
-                { chat: "11" },
-                "!mmm chat: ${1 + ?((2 * 3 + 4))}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>10</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?((2 * 3 + 4))</span>" },
-                { chat: "11" },
-                "!mmm chat: ${1 + ?(2 * 3 + ? 4)}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>4</span> ◀️ 1 + ?(2 * 3 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>? 4</span>)" },
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>10</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?(2 * 3 + ? 4)</span>" },
-                { chat: "11" },
-                "!mmm chat: ${1 + ?getattr('Dummy', 'AP')}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>20</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?getattr('Dummy', 'AP')</span>" },
-                { chat: "21" },
-                "!mmm chat: ${?('foo' & 123 & 'bar')}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>\"foo123bar\"</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?('foo' &amp; 123 &amp; 'bar')</span>" },
-                { chat: "foo123bar" },
-                "!mmm chat: ${1 + ? 2**3 * 4 <= 5}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>2</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>? 2</span>**3 * 4 &lt;= 5" },
-                { chat: "false" },
-                "!mmm chat: ${1 + ?? 2**3 * 4 <= 5}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>32</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?? 2**3 * 4</span> &lt;= 5" },
-                { chat: "false" },
-                "!mmm chat: ${1 + ??? 2**3 * 4 <= 5}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>32</span> ◀️ 1 + <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>??? 2**3 * 4</span> &lt;= 5" },
-                { chat: "false" },
-                "!mmm chat: ${? 2**3 * 4 <= 5}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>2</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>? 2</span>**3 * 4 &lt;= 5" },
-                { chat: "false" },
-                "!mmm chat: ${?? 2**3 * 4 <= 5}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>32</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>?? 2**3 * 4</span> &lt;= 5" },
-                { chat: "false" },
-                "!mmm chat: ${??? 2**3 * 4 <= 5}",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>false</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>??? 2**3 * 4 &lt;= 5</span>" },
-                { chat: "false" },
                 "!mmm chat: ${? default + 123}",
-                { whisper: "🔎 <span style=\"background: gray; border: 2px solid gray; color: white; font-weight: bold\">default</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>? default</span> + 123" },
+                { whisper: "🔎 <span style=\"background: gray; border: 2px solid gray; color: white; font-weight: bold\">default</span> ◀️ ? <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>default</span> + 123" },
                 { chat: "123" },
                 "!mmm chat: ${? denied + 123}",
-                { whisper: "🔎 <span class=\"mmm-denied\" style=\"background: red; border: 2px solid red; color: white; font-weight: bold\">denied</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>? denied</span> + 123" },
+                { whisper: "🔎 <span class=\"mmm-denied\" style=\"background: red; border: 2px solid red; color: white; font-weight: bold\">denied</span> ◀️ ? <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>denied</span> + 123" },
                 { chat: "123" },
                 "!mmm chat: ${? unknown + 123}",
-                { whisper: "🔎 <span class=\"mmm-unknown\" style=\"background: darkorange; border: 2px solid darkorange; color: white; font-weight: bold\">unknown</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>? unknown</span> + 123" },
+                { whisper: "🔎 <span class=\"mmm-unknown\" style=\"background: darkorange; border: 2px solid darkorange; color: white; font-weight: bold\">unknown</span> ◀️ ? <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>unknown</span> + 123" },
                 { chat: "123" },
             ],
             [
@@ -363,10 +310,10 @@
                 { whisper: "🔎 <span class=\"mmm-denied\" style=\"background: red; border: 2px solid red; color: white; font-weight: bold\">denied</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>denied</span>" },
                 "!mmm debug do unknown",
                 { whisper: "🔎 <span class=\"mmm-unknown\" style=\"background: darkorange; border: 2px solid darkorange; color: white; font-weight: bold\">unknown</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>unknown</span>" },
-                "!mmm debug do getattr('Dummy', 'AP')",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>20</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>getattr('Dummy', 'AP')</span>" },
-                "!mmm debug do setattr('Dummy', 'AP', getattr('Dummy', 'AP') - 1)",
-                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>19</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>setattr('Dummy', 'AP', getattr('Dummy', 'AP') - 1)</span>" },
+                "!mmm debug do getattr('Finn', 'HP')",
+                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>\"20\"</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>getattr('Finn', 'HP')</span>" },
+                "!mmm debug do setattr('Finn', 'HP', getattr('Finn', 'HP') - 1)",
+                { whisper: "🔎 <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>\"19\"</span> ◀️ <span style='background: #E0E0E0; padding: 0em 0.3em; border: 2px solid silver; border-radius: 0.5em; color: black; white-space: pre-wrap'>setattr('Finn', 'HP', getattr('Finn', 'HP') - 1)</span>" },
             ],
             [
                 "!mmm debug chat: number is ${3.141}",
@@ -409,8 +356,8 @@
             [
                 "!mmm if false",
                 "!mmm else if broken syntax in expression",
+                { error: "During parse, expected binary operator, or property lookup, or opening parenthesis (for function arguments), or opening bracket (for array subscript), or end of expression in expression in script: else if broken ❌syntax in expression" },
                 "!mmm end if",
-                { error: "During execute, any identifier not expected here (expected binary operator) in expression in script: !mmm else if broken ❌syntax in expression" },
             ],
             [
                 "!mmm if true",
@@ -451,89 +398,6 @@
                 "!mmm    chat: correct[1/1]",
                 "!mmm end if",
                 { chat: "correct[1/1]" },
-            ],
-            [
-                "!mmm script",
-                "!mmm     chat: argnum() = ${argnum()}",
-                "!mmm     chat: argnum(1,2,3,4) = ${argnum(1,2,3,4)}",
-                "!mmm     chat: argnum(1,(2,3,4)) = ${argnum(1,(2,3,4))}",
-                "!mmm     chat: argnum((1,2,3),4) = ${argnum((1,2,3),4)}",
-                "!mmm     chat: argnum((1,2),(3,4)) = ${argnum((1,2),(3,4))}",
-                "!mmm end script",
-                { chat: "argnum() = 0" },
-                { chat: "argnum(1,2,3,4) = 4" },
-                { chat: "argnum(1,(2,3,4)) = 4" },
-                { chat: "argnum((1,2,3),4) = 4" },
-                { chat: "argnum((1,2),(3,4)) = 4" },
-            ],
-            [
-                "!mmm script",
-                "!mmm     set list567 = 5,6,7",
-                "!mmm     chat: argnum(list567) = ${argnum(list567)}",
-                "!mmm     chat: argnum(1,list567) = ${argnum(1,list567)}",
-                "!mmm     chat: argnum(list567,2) = ${argnum(list567,2)}",
-                "!mmm     chat: argnum(1,list567,2) = ${argnum(1,list567,2)}",
-                "!mmm     chat: listnum(arg1(1,list567,2)) = ${listnum(arg1(1,list567,2))}",
-                "!mmm end script",
-                { chat: "argnum(list567) = 1" },
-                { chat: "argnum(1,list567) = 2" },
-                { chat: "argnum(list567,2) = 2" },
-                { chat: "argnum(1,list567,2) = 3" },
-                { chat: "listnum(arg1(1,list567,2)) = 3" },
-            ],
-            [
-                "!mmm script",
-                "!mmm     chat: argnum(undef) = ${argnum(undef)}",
-                "!mmm     chat: argnum(1,undef) = ${argnum(1,undef)}",
-                "!mmm     chat: argnum(undef,2) = ${argnum(undef,2)}",
-                "!mmm     chat: argnum(1,undef,2) = ${argnum(1,undef,2)}",
-                "!mmm end script",
-                { chat: "argnum(undef) = 1" },
-                { chat: "argnum(1,undef) = 2" },
-                { chat: "argnum(undef,2) = 2" },
-                { chat: "argnum(1,undef,2) = 3" },
-            ],
-            [
-                "!mmm script",
-                "!mmm     chat: argnum(denied) = ${argnum(denied)}",
-                "!mmm     chat: argnum(1,denied) = ${argnum(1,denied)}",
-                "!mmm     chat: argnum(denied,2) = ${argnum(denied,2)}",
-                "!mmm     chat: argnum(1,denied,2) = ${argnum(1,denied,2)}",
-                "!mmm     chat: isdenied(arg1(1,denied,2)) = ${isdenied(arg1(1,denied,2))}",
-                "!mmm end script",
-                { chat: "argnum(denied) = 1" },
-                { chat: "argnum(1,denied) = 2" },
-                { chat: "argnum(denied,2) = 2" },
-                { chat: "argnum(1,denied,2) = 3" },
-                { chat: "isdenied(arg1(1,denied,2)) = true" },
-            ],
-            [
-                "!mmm script",
-                "!mmm     chat: argnum(unknown) = ${argnum(unknown)}",
-                "!mmm     chat: argnum(1,unknown) = ${argnum(1,unknown)}",
-                "!mmm     chat: argnum(unknown,2) = ${argnum(unknown,2)}",
-                "!mmm     chat: argnum(1,unknown,2) = ${argnum(1,unknown,2)}",
-                "!mmm     chat: isunknown(arg1(1,unknown,2)) = ${isunknown(arg1(1,unknown,2))}",
-                "!mmm end script",
-                { chat: "argnum(unknown) = 1" },
-                { chat: "argnum(1,unknown) = 2" },
-                { chat: "argnum(unknown,2) = 2" },
-                { chat: "argnum(1,unknown,2) = 3" },
-                { chat: "isunknown(arg1(1,unknown,2)) = true" },
-            ],
-            [
-                "!mmm script",
-                "!mmm     chat: argnum(default) = ${argnum(default)}",
-                "!mmm     chat: argnum(1,default) = ${argnum(1,default)}",
-                "!mmm     chat: argnum(default,2) = ${argnum(default,2)}",
-                "!mmm     chat: argnum(1,default,2) = ${argnum(1,default,2)}",
-                "!mmm     chat: isdefault(arg1(1,default,2)) = ${isdefault(arg1(1,default,2))}",
-                "!mmm end script",
-                { chat: "argnum(default) = 1" },
-                { chat: "argnum(1,default) = 2" },
-                { chat: "argnum(default,2) = 2" },
-                { chat: "argnum(1,default,2) = 3" },
-                { chat: "isdefault(arg1(1,default,2)) = true" },
             ],
             [
                 "!mmm script",
@@ -881,10 +745,10 @@
                 "!mmm combine chat",
                 "!mmm     chat: Hello World!",
                 "!mmm     chat: Meaning of life: ${6*7},",
-                "!mmm     chat: current AP: ${getattr('Dummy', 'AP')}",
+                "!mmm     chat: current HP: ${getattr('Finn', 'HP')}",
                 "!mmm     do chat('and even from expressions')",
                 "!mmm end combine",
-                { chat: "Hello World! Meaning of life: 42, current AP: 19 and even from expressions" },
+                { chat: "Hello World! Meaning of life: 42, current HP: 19 and even from expressions" },
             ],
             [
                 "!mmm combine chat using '//'",
@@ -1029,10 +893,10 @@
             [
                 "!mmm script",
                 "!mmm     do roll('1d20')",
-                "!mmm     do syntax error",
+                "!mmm     do runtimeError()",
                 "!mmm end script",
                 { process: "/roll 1d20" },
-                { error: "During execute, any identifier not expected here (expected binary operator) in expression in script: !mmm     do syntax ❌error" },
+                { error: "During execute, unknown function in expression in script: !mmm     do runtimeError❌()" },
             ],
             [
                 "!mmm script",
@@ -1213,13 +1077,13 @@
                 "!mmm end customize",
                 "!mmm customize",
                 "!mmm     set foo = 'broken'",
-                "!mmm     do syntax error",
+                "!mmm     do runtimeError()",
                 "!mmm end customize",
                 "!mmm script",
                 "!mmm     set customizable foo",
                 "!mmm     chat: correct, foo=${foo}",
                 "!mmm end script",
-                { whisper: "During customize, any identifier not expected here (expected binary operator) in expression in script:     do syntax ❌error" },
+                { whisper: "During customize, unknown function in expression in script:     do runtimeError❌()" },
                 { chat: "correct, foo=correct" },
             ],
             [
@@ -1283,19 +1147,19 @@
                 "!mmm end customize",
                 "!mmm script",
                 "!mmm     set meaning = 42",
-                "!mmm     chat [foo]: meaning is $[once]{meaning}, twice the meaning is $[twice]{syntax error meaning*2}, thrice is ${meaning*3}",
+                "!mmm     chat [foo]: meaning is $[once]{meaning}, twice the meaning is $[twice]{runtimeError()*2}, thrice is ${meaning*3}",
                 "!mmm end script",
-                { error: "During execute, any identifier not expected here (expected binary operator) in expression in template in script: !mmm     chat [foo]: meaning is $[once]{meaning}, twice the meaning is $[twice]{syntax ❌error meaning*2}, thrice is ${meaning*3}" },
+                { error: "During execute, unknown function in expression in template in script: !mmm     chat [foo]: meaning is $[once]{meaning}, twice the meaning is $[twice]{runtimeError❌()*2}, thrice is ${meaning*3}" },
             ],
             [
                 "!mmm customize",
-                "!mmm     set customizedSetting = 'correct \"customized\" setting'",
+                "!mmm     set customizedSetting = 'correct ' & '\"customized\"' & ' setting'",
                 "!mmm     translate [translatedChat]: correct translated chat message with $[correct_placeholder]",
                 "!mmm end customize",
                 "!mmm script",
                 "!mmm     set customizable customizedSetting = 'broken'",
-                "!mmm     set customizable settingWithSimpleDefault = 'correct \"default\" setting'",
-                "!mmm     set customizable settingWithExpressionDefault = 'correct ' & '\"default\"' & ' setting'",
+                "!mmm     set customizable settingWithConstantDefault = 'correct ' & '\"default\"' & ' setting'",
+                "!mmm     set customizable settingWithVariableDefault = 'correct ' & '\"default\"' & ' setting' & variable",
                 "!mmm     chat [translatedChat]: broken translated chat with $[correct_placeholder]{'correct labeled expression'}",
                 "!mmm     chat [defaultChat]: correct default chat with $[broken_placeholder]{'correct labeled expression'} and ${'correct expression without label'} and $[correct_misplaced_label]",
                 "!mmm     chat [defaultChat]: correct redundant default chat with $[broken_placeholder]{'correct labeled expression'} and ${'correct expression without label'} and $[correct_misplaced_label]",
@@ -1307,25 +1171,25 @@
             [
                 "!mmm customize export to chat",
                 "!mmm customize",
-                "!mmm     set customizedSetting = 'correct \"customized\" setting'",
-                "!mmm     translate [translatedChat]: correct translated chat message with $[placeholder]",
+                "!mmm     set customizedSetting = 'correct ' & '\"customized\"' & ' setting'",
+                "!mmm     translate [translatedChat]: correct translated chat message with $[correct_placeholder]",
                 "!mmm end customize",
                 "!mmm script",
                 "!mmm     set customizable customizedSetting = 'broken'",
                 "!mmm     set customizable settingWithoutDefault",
-                "!mmm     set customizable settingWithSimpleDefault = 'correct \"default\" setting'",
-                "!mmm     set customizable settingWithExpressionDefault = 'correct ' & '\"default\"' & ' setting'",
+                "!mmm     set customizable settingWithConstantDefault = 'correct ' & '\"default\"' & ' setting'",
+                "!mmm     set customizable settingWithVariableDefault = 'correct ' & '\"default\"' & ' setting' & variable",
                 "!mmm     chat [translatedChat]: broken translated chat with $[correct_placeholder]{'labeled expression'}",
-                "!mmm     chat [defaultChat]: correct default chat with $[correct_placeholder]{'broken labeled expression'} and ${'broken expression without label'} and $[broken_misplaced_label]",
+                "!mmm     chat [defaultChat]: correct default chat with $[correct_placeholder]{'broken labeled expression'} and ${'broken expression without label'} and $[correct_misplaced_label]",
                 "!mmm     chat [defaultChat]: broken redundant default chat with $[broken_placeholder]{'broken labeled expression'} and ${'broken expression without label'} and $[broken_misplaced_label]",
                 "!mmm end script",
                 { whisper: "<span style='white-space: pre'>!mmm customize<br/>" +
                            "!mmm    set customizedSetting = \"correct \\\"customized\\\" setting\"<br/>" +
                            "!mmm    set settingWithoutDefault = 🤔<br/>" +
-                           "!mmm    set settingWithSimpleDefault = \"correct \\\"default\\\" setting\"<br/>" +
-                           "!mmm    set settingWithExpressionDefault = default<br/>" +
-                           "!mmm    translate [translatedChat]: correct translated chat message with ...<br/>" +
-                           "!mmm    translate [defaultChat]: correct default chat with $[correct_placeholder] and ... and ...<br/>" +
+                           "!mmm    set settingWithConstantDefault = \"correct \\\"default\\\" setting\"<br/>" +
+                           "!mmm    set settingWithVariableDefault = default<br/>" +
+                           "!mmm    translate [translatedChat]: correct translated chat message with $[correct_placeholder]<br/>" +
+                           "!mmm    translate [defaultChat]: correct default chat with $[correct_placeholder] and ... and $[correct_misplaced_label]<br/>" +
                            "!mmm end customize</span>" },
             ],
             [
@@ -1350,28 +1214,21 @@
 
         let attributes =
         {
-            AP: { current: 20, max: 30 },
+            Finn:
+            {
+                name: { current: "Finn MacRathgar" },
+                HP: { current: 20, max: 30 },
+                LP: { current: 15, max: 25 },
+                cousin: { current: "Yorrick" },
+            },
+            Yorrick:
+            {
+                name: { current: "Yorrick MacRathgar" },
+                HP: { current: 18, max: 28 },
+                LP: { current: 13, max: 23 },
+                cousin: { current: "Finn" },
+            },
         };
-
-        MychScriptContext.prototype.argnum = function(...args)
-        {
-            return args.length;
-        }
-
-        MychScriptContext.prototype.arg0 = function(...args)
-        {
-            return args[0];
-        }
-
-        MychScriptContext.prototype.arg1 = function(...args)
-        {
-            return args[1];
-        }
-
-        MychScriptContext.prototype.arg2 = function(...args)
-        {
-            return args[2];
-        }
 
         MychScriptContext.prototype.listnum = function(list)
         {
@@ -1433,36 +1290,94 @@
             });
         };
 
+        MychScriptContext.prototype.$getAttribute = function(characterNameOrId, attributeName, max = false)
+        {
+            if (characterNameOrId instanceof MychScriptContext.DiagnosticUndef)
+            {
+                return characterNameOrId;
+            }
+
+            if (attributeName instanceof MychScriptContext.DiagnosticUndef)
+            {
+                return attributeName;
+            }
+
+            characterNameOrId = MychExpression.coerceString(characterNameOrId);
+
+            let attributesForCharacter = attributes[characterNameOrId];
+
+            if (!attributesForCharacter)
+            {
+                return new MychScriptContext.Unknown("Unknown character: " + characterNameOrId);
+            }
+
+            attributeName = MychExpression.coerceString(attributeName);
+            
+            let attribute = attributesForCharacter[attributeName];
+
+            if (!attribute)
+            {
+                return new MychScriptContext.Unknown("Unknown attribute: " + attributeName);
+            }
+
+            return MychExpression.coerceString(max ? attribute.max : attribute.current);
+        }
+
         MychScriptContext.prototype.getattr = function(characterNameOrId, attributeName)
         {
-            return attributes[attributeName].current;
+            return this.$getAttribute(characterNameOrId, attributeName, false);
         }
 
         MychScriptContext.prototype.getattrmax = function(characterNameOrId, attributeName)
         {
-            return attributes[attributeName].max;
+            return this.$getAttribute(characterNameOrId, attributeName, true);
+        }
+
+        MychScriptContext.prototype.$setAttribute = function(characterNameOrId, attributeName, attributeValue, max = false)
+        {
+            if (characterNameOrId instanceof MychScriptContext.DiagnosticUndef)
+            {
+                return characterNameOrId;
+            }
+
+            if (attributeName instanceof MychScriptContext.DiagnosticUndef)
+            {
+                return attributeName;
+            }
+
+            characterNameOrId = MychExpression.coerceString(characterNameOrId);
+
+            let attributesForCharacter = attributes[characterNameOrId];
+
+            if (!attributesForCharacter)
+            {
+                return new MychScriptContext.Unknown("Unknown character: " + characterNameOrId);
+            }
+
+            attributeName = MychExpression.coerceString(attributeName);
+            attributeValue = MychExpression.coerceString(attributeValue);
+
+            let attribute = attributesForCharacter[attributeName];
+
+            if (!attribute)
+            {
+                attribute = { current: undefined, max: undefined };
+                attributesForCharacter[attributeName] = attribute;
+            }
+
+            attribute[max ? "max" : "current"] = MychExpression.coerceString(attributeValue);
+
+            return this.$getAttribute(characterNameOrId, attributeName, max);
         }
 
         MychScriptContext.prototype.setattr = function(characterNameOrId, attributeName, attributeValue)
         {
-            if (attributes[attributeName] == undefined)
-            {
-                attributes[attributeName] = { current: undefined, max: undefined };
-            }
-
-            attributes[attributeName].current = attributeValue;
-            return attributeValue;
+            return this.$setAttribute(characterNameOrId, attributeName, attributeValue, false);
         }
 
         MychScriptContext.prototype.setattrmax = function(characterNameOrId, attributeName, attributeValue)
         {
-            if (attributes[attributeName] == undefined)
-            {
-                attributes[attributeName] = { current: undefined, max: undefined };
-            }
-
-            attributes[attributeName].max = attributeValue;
-            return attributeValue;
+            return this.$setAttribute(characterNameOrId, attributeName, attributeValue, true);
         }
 
         function getObj(type, id)


### PR DESCRIPTION
Character or token attribute lookups can now be done with this syntax:
- Use `nameOrId.attrName` for `getattr(nameOrId, "attrName")`
- Use `nameOrId.attrName.max` for `getattrmax(nameOrId, "attrName")`
- These property lookups can be chained: `charName.Familiar.HP.max`
- Variable attribute name expressions: `nameOrId.(weapon & "attack")`

Rewrite MychExpression engine:
- Implemented as fully declarative rule-based parser.
- Syntax errors reported at parse time, not at runtime.
- Supports parse-time constant expressions.

Improve expressions test suite:
- Tests expressions against expected results or errors.
- Tests parse-time constant expression results against runtime results.
- Reports test failures.
- Includes pure expression function tests previously in scripts suite.

Improve scripts test suite:
- Move pure expression function tests to expressions suite.
- Mock `getattr()` suite of functions more closely like the real thing.

Version: 1.20.0