### PR TITLE
Fix `isdefault()`, `isdenied()`, `isunknown()`, and `getreason()` with `id.attr` results

### DIFF
--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -1,7 +1,7 @@
 // Mych's Macro Magic by Michael Buschbeck <michael@buschbeck.net> (2021)
 // https://github.com/michael-buschbeck/mychs-macro-magic/blob/main/LICENSE
 
-const MMM_VERSION = "1.20.2";
+const MMM_VERSION = "1.20.3";
 
 on("chat:message", function(msg)
 {
@@ -237,11 +237,6 @@ class MychScriptContext
         }
     }
 
-    isdefault(value)
-    {
-        return (value instanceof MychScriptContext.Default);
-    }
-
     static DiagnosticUndef = class
     {
         constructor(reason = undefined)
@@ -284,14 +279,49 @@ class MychScriptContext
         textColor = "white";
     }
 
+    isdefault(value)
+    {
+        if (value instanceof MychScriptContext.Default)
+        {
+            return true;
+        }
+
+        if (value && value.toScalar instanceof Function)
+        {
+            return this.isdefault(value.toScalar());
+        }
+
+        return false;
+    }
+
     isunknown(value)
     {
-        return (value instanceof MychScriptContext.Unknown);
+        if (value instanceof MychScriptContext.Unknown)
+        {
+            return true;
+        }
+
+        if (value && value.toScalar instanceof Function)
+        {
+            return this.isunknown(value.toScalar());
+        }
+
+        return false;
     }
 
     isdenied(value)
     {
-        return (value instanceof MychScriptContext.Denied);
+        if (value instanceof MychScriptContext.Denied)
+        {
+            return true;
+        }
+
+        if (value && value.toScalar instanceof Function)
+        {
+            return this.isdenied(value.toScalar());
+        }
+
+        return false;
     }
 
     getreason(value)
@@ -299,6 +329,11 @@ class MychScriptContext
         if (value instanceof MychScriptContext.DiagnosticUndef)
         {
             return value.reason;
+        }
+
+        if (value && value.toScalar instanceof Function)
+        {
+            return this.getreason(value.toScalar());
         }
         
         return new MychScriptContext.Unknown("Only <strong>denied</strong> and <strong>unknown</strong> values can have a reason");

--- a/test/expressions.html
+++ b/test/expressions.html
@@ -369,6 +369,26 @@
                 { result: "\"15\"" },
             ],
             [
+                "'Char1'.HP",
+                { result: "\"15\"" },
+            ],
+            [
+                "getattr('Char1', 'XX')",
+                { result: "[unknown: Unknown attribute: XX]" },
+            ],
+            [
+                "'Char1'.XX",
+                { result: "[unknown: Unknown attribute: XX]" },
+            ],
+            [
+                "isunknown(getattr('Char1', 'XX'))",
+                { result: "true" },
+            ],
+            [
+                "isunknown('Char1'.XX)",
+                { result: "true" },
+            ],
+            [
                 "async('background process', 999)",
                 { yield: "\"background process\"" },
                 { result: "999" },

--- a/test/expressions.html
+++ b/test/expressions.html
@@ -400,11 +400,11 @@
             ],
             [
                 "noStruct.someProp",
-                { result: "\"(unknown property 'someProp')\"" },
+                { result: "[unknown: Unknown attribute: someProp]" },
             ],
             [
                 "'literal string'.someProp",
-                { result: "\"(unknown property 'someProp')\"" },
+                { result: "[unknown: Unknown attribute: someProp]" },
             ],
             [
                 "6+++++7",
@@ -751,18 +751,19 @@
 
         MychScriptContext.prototype.getattr = function(characterName, attributeName)
         {
-            return "15";
+            switch (attributeName)
+            {
+                case "HP":
+                    return "15";
+            }
+
+            return new MychScriptContext.Unknown("Unknown attribute: " + attributeName);
         }
 
         MychScriptContext.prototype.async = function*(intermediate, result)
         {
             yield intermediate;
             return result;
-        }
-
-        MychScriptContext.prototype.getprop = function(struct, key)
-        {
-            return "(unknown property '" + key + "')";
         }
 
         MychScriptContext.prototype.$debugSendExpression = function(result, source, resultSourceBegin = 0, resultSourceEnd = source.length)
@@ -798,6 +799,33 @@
                 propC: "C!",
             },
         };
+
+        function getResultRepresentation(context, result)
+        {
+            if (context.isdefault(result))
+            {
+                return "[default]";
+            }
+
+            if (context.isunknown(result))
+            {
+                let reason = context.getreason(result);
+                return reason ? ("[unknown: " + reason + "]") : "[unknown]";
+            }
+
+            if (context.isdenied(result))
+            {
+                let reason = context.getreason(result);
+                return reason ? ("[denied: " + reason + "]") : "[denied]";
+            }
+
+            if (result && result.toScalar instanceof Function)
+            {
+                return getResultRepresentation(context, result.toScalar());
+            }
+
+            return MychExpression.literal(result);
+        }
 
         let numTestsRun = 0;
         let numTestsSuccessful = 0;
@@ -838,14 +866,14 @@
                     outputs.push(
                     {
                         type: "yield",
-                        text: MychExpression.literal(resultContainer.value),
+                        text: getResultRepresentation(expression.context, resultContainer.value),
                     });
                 }
 
                 outputs.push(
                 {
                     type: "result",
-                    text: MychExpression.literal(resultContainer.value),
+                    text: getResultRepresentation(expression.context, resultContainer.value),
                 });
 
                 if (expression.isConstant())


### PR DESCRIPTION
Version: 1.20.3