### PR TITLE
various scripts: fix cases where numerical input w/"+" prefix got pre…

### DIFF
--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "1.4.3 (2021-10-20)"
+!mmm   set scriptVersion = "1.4.4 (2021-12-03)"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
 !mmm   if version < 1.20
@@ -107,7 +107,7 @@
 !mmm   set modifiers = modifiers + autoModifiers + semiManualModifiers + manualModifiers
 !mmm   if manualModifiers != 0
 !mmm     if manualModifiers > 0
-!mmm       set manualModifiers = "+" & manualModifiers
+!mmm       set manualModifiers = "+" & (manualModifiers * 1)
 !mmm     end if
 !mmm     set modifierLog = modifierLog & " {{Manuelle Modifikatoren=" & manualModifiers & "}} "
 !mmm     set modifierTooltip = modifierTooltip & " Manuelle&nbsp;Modifikatoren&nbsp;&nbsp;&nbsp;" & manualModifiers & " "

--- a/examples/midgard/meleeAttack/earthBondRemove.mmm
+++ b/examples/midgard/meleeAttack/earthBondRemove.mmm
@@ -16,7 +16,7 @@
 !mmm   set customizable cDeactivateGIF = ""
 !mmm
 !mmm   if cCheckVersion
-!mmm     do whisperback("earthBondCreate v" & scriptVersion)
+!mmm     do whisperback("earthBondRemove v" & scriptVersion)
 !mmm     exit script
 !mmm   end if
 !mmm

--- a/examples/midgard/meleeAttack/meleeAttack.mmm
+++ b/examples/midgard/meleeAttack/meleeAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Melee Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "v1.9.0 (2021-11-18)"
+!mmm   set scriptVersion = "v1.9.1 (2021-12-03)"
 !rem
 !rem   // MMM compatibility check: die if MMM version too low
 !mmm   if version < 1.18
@@ -161,7 +161,7 @@
 !mmm   set manualModifiers = "?{Weitere spezielle Angriffsmodifikatoren|0}"
 !mmm   if manualModifiers != 0
 !mmm     if manualModifiers > 0
-!mmm       set manualModifiers = "+" & manualModifiers
+!mmm       set manualModifiers = "+" & (manualModifiers * 1)
 !mmm     end if
 !mmm     set modifierLog = modifierLog & " {{Benutzereingabe=" & manualModifiers & "}} "
 !mmm     set modifierTooltip = modifierTooltip & " Benutzereingabe&nbsp;&nbsp;&nbsp;" & manualModifiers & " "

--- a/examples/midgard/rangedAttack/rangedAttack.mmm
+++ b/examples/midgard/rangedAttack/rangedAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Ranged Attack Script
 !rem
 !mmm script
-!mmm   set scriptVersion = "1.9.0 (2021-11-18)"
+!mmm   set scriptVersion = "1.9.1 (2021-12-03)"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
 !mmm   if version < 1.16
@@ -244,7 +244,7 @@
 !mmm   set manualModifiers = "?{Weitere spezielle Angriffsmodifikatoren|0}"
 !mmm   if manualModifiers != 0
 !mmm     if manualModifiers > 0
-!mmm       set manualModifiers = "+" & manualModifiers
+!mmm       set manualModifiers = "+" & (manualModifiers * 1)
 !mmm     end if
 !mmm     set modifierLog = modifierLog & " {{Benutzereingabe=" & manualModifiers & "}} "
 !mmm     set modifierTooltip = modifierTooltip & " Benutzereingabe&nbsp;&nbsp;&nbsp;" & manualModifiers & " "

--- a/examples/midgard/rangedAttack/waterWalkerBlastAttack.mmm
+++ b/examples/midgard/rangedAttack/waterWalkerBlastAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Ranged Attack Script, special version for magic beam attack (rune blade "Water Walker")
 !rem
 !mmm script
-!mmm   set scriptVersion = "1.0.3 (2021-11-17, built on rangedAttack 1.8.10)"
+!mmm   set scriptVersion = "1.0.4 (2021-12-03, built on rangedAttack 1.8.10)"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
 !mmm   if version < 1.20
@@ -189,7 +189,7 @@
 !mmm   set manualModifiers = ?{Weitere spezielle Angriffsmodifikatoren|0}
 !mmm   if manualModifiers != 0
 !mmm     if manualModifiers > 0
-!mmm       set manualModifiers = "+" & manualModifiers
+!mmm       set manualModifiers = "+" & (manualModifiers * 1)
 !mmm     end if
 !mmm     set modifierLog = modifierLog & " {{Benutzereingabe=" & manualModifiers & "}} "
 !mmm     set modifierTooltip = modifierTooltip & " Benutzereingabe&nbsp;&nbsp;&nbsp;" & manualModifiers & " "

--- a/examples/midgard/sense/senseLogic.mmm
+++ b/examples/midgard/sense/senseLogic.mmm
@@ -1,9 +1,9 @@
 !rem // Midgard Multi-Sense Script 
-!rem // v1.1.2 2021-10-12
 !rem //
 !rem // senseMainLogic -- must be called from a config script
 !rem //
 !mmm script
+!mmm   set scriptVersion = "1.1.3 (2021-12-03)"
 !rem
 !rem   // MMM compatibility check: die if MMM version too low
 !mmm   if version < 1.19
@@ -13,6 +13,7 @@
 !rem
 !rem   // Config: set defaults for customizable variables
 !rem   //
+!rem   //  cCheckVersion            Toggle version check
 !rem   //  cSense                   Must be one of the sense skills in the character sheet table "sinne", column "Fertigkeit2"
 !rem   //  cSenseModifier           Modifier to the sense roll
 !rem   //  cSuccessMessage,         Text to be sent to players in case of success / failure / critical failure, or in case 
@@ -20,12 +21,18 @@
 !rem   //  cCriticalFailureMessage     
 !rem   //  cTokenList               List of valid token_id values for characters that get the sense rolls. Duplicates are ignored.
 !rem   //
+!mmm   set customizable cCheckVersion = false
 !mmm   set customizable cSense = "Sehen"
 !mmm   set customizable cSenseModifier = 0
 !mmm   set customizable cSuccessMessage = "Einer deiner Sinne hat etwas wahrgenommen. Herzlichen Glückwunsch!"
 !mmm   set customizable cRegularFailureMessage = "Nichts besonderes hier."
 !mmm   set customizable cCriticalFailureMessage = "Nichts besonderes hier. Wirklich nicht!"
 !mmm   set customizable cTokenList = false
+!mmm
+!mmm   if cCheckVersion
+!mmm     do whisperback("Midgard Multi Sense Script " & scriptVersion)
+!mmm     exit script
+!mmm   end if
 !mmm
 !rem   // Initialize 
 !rem   //
@@ -86,7 +93,7 @@
 !mmm         set senseRoll = roll("1d20" & effModifier)
 !rem         // Overwrite tooltip to break down components
 !mmm         if charSenseModifier >= 0
-!mmm           set charSenseModifier = "+" & charSenseModifier
+!mmm           set charSenseModifier = "+" & (charSenseModifier * 1)
 !mmm         end if
 !mmm         set senseResultTooltip = senseRoll & " = (1d20 = " & (senseRoll - effModifier) & ") + (EW = " & charEffectiveSkill & ") " & charSenseModifier
 !mmm         set senseResult = highlight(senseRoll, default, senseResultTooltip)


### PR DESCRIPTION
…fixed again, which led a some cases with bonuses given as "++2" which could not be processed. Now, users are free (again) to use the plus sign or not when entering numerical data into popup dialogue boxes.