### PR TITLE
Temporary attribute restrictions for endurance in case of severe injuries

### DIFF
--- a/examples/midgard/dataExchange/showExchange.mmm
+++ b/examples/midgard/dataExchange/showExchange.mmm
@@ -2,7 +2,7 @@
 !rem // 
 !mmm script
 !mmm 
-!mmm   set scriptVersion = "showExchange 1.1.0 (2021-12-22)"
+!mmm   set scriptVersion = "showExchange 1.2.0 (2022-01-15)"
 !mmm
 !mmm   set CURRENT = scriptVersion
 %{MacroSheetLibrary|libMidgardGlobal}
@@ -15,7 +15,15 @@
 !mmm   combine chat
 !mmm     chat: /w "${user}" ${"&"}{template:default} {{name=m3mgd tools: showExchange}}
 !mmm     for attribute in m3mgdExchangeAttrList
-!mmm       chat: {{ ${attribute}=${m3mgdExchange.(attribute)} / ${m3mgdExchange.(attribute).max}}}
+!mmm       set showValue = m3mgdExchange.(attribute)
+!mmm       if showValue.name
+!mmm         set showValue = highlight(m3mgdExchange.(attribute).name, "normal", m3mgdExchange.(attribute))
+!mmm       end if
+!mmm       set showMaxValue = m3mgdExchange.(attribute).max
+!mmm       if showMaxValue.name
+!mmm         set showMaxValue = highlight(m3mgdExchange.(attribute).max.name, "normal", m3mgdExchange.(attribute).max)
+!mmm       end if
+!mmm       chat: {{ ${attribute}=${showValue} / ${showMaxValue} }}
 !mmm     end for
 !mmm   end combine
 !mmm end script

--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "defense 1.11.0 (2022-01-14)"
+!mmm   set scriptVersion = "defense 1.12.0 (2022-01-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -261,6 +261,11 @@
 !mmm     set timeToDie = roll("1d6-" & abs(newHealth)) 
 !mmm   end if
 !mmm   set effHealthLoss = highlight(effHealthLoss, "info")
+!mmm
+!rem   // Process or indicate if an endurance ceiling is in place (for serious injuries, health <= 50%)
+!mmm   if m3mgdAttrCeiling(cOwnID, cEnduranceAttr)
+!mmm     set newEndurance = highlight(cOwnID.(cEnduranceAttr), "important", "Schwächelnd bis der Heiler kommt (max. " & round(cOwnID.(cEnduranceAttr).max/2) & "=50%)")
+!mmm   end if
 !rem
 !rem   // Process experience gain for attacker if script is run on an NPC, in which case player is GM with control over attacker sheet
 !mmm   if (cOwnID.(cEnduranceAttr).max == 0 and not defenseSuccess) or (cOwnID.(cEnduranceAttr).max != 0 and endurance > 0 and effEnduranceLoss > 0)

--- a/examples/midgard/defense/libDefenseDataTable.mmm
+++ b/examples/midgard/defense/libDefenseDataTable.mmm
@@ -6,7 +6,7 @@
 !rem
 !mmm   set prvEndurance = script.endurance
 !mmm   set prvHealth = script.health
-!mmm   set shapeMoji = m3mgdShapeMoji(cOwnID, cHealthAttr, cEnduranceAttr)
+!mmm   set shapeMoji = m3mgdShapeMoji(script.cOwnID, script.cHealthAttr, script.cEnduranceAttr)
 !mmm
 !mmm   if script.criticalAttack
 !mmm     set attackResult = highlight(script.attackResult, "good", "Kritisch erfolgreicher Angriff von " & script.m3mgdExchange.(m3mgdAttrAttackerID).name)

--- a/examples/midgard/health/applyHealing.mmm
+++ b/examples/midgard/health/applyHealing.mmm
@@ -2,11 +2,11 @@
 !rem //
 %{MacroSheetLibrary|libMidgardFunctions}
 !mmm script
-!mmm   set scriptVersion = "applyHealing 1.0.1 (2022-01-12)"
+!mmm   set scriptVersion = "applyHealing 1.1.0 (2022-01-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
-!mmm     do whisperback("Midgard script " & scriptVersion)
+!mmm     do whisperback(scriptVersion)
 !mmm     exit script
 !mmm   end if
 !mmm
@@ -24,16 +24,32 @@
 !mmm     set user = cOwnID.name
 !mmm   end if
 !mmm   
-!mmm   if not (m3mgdExchange.(m3mgdAttrHealthGain) > 0 or m3mgdExchange.(m3mgdAttrEnduranceGain) > 0)
+!mmm   set maxEnduranceGain = m3mgdExchange.(m3mgdAttrEnduranceGain)
+!mmm   set maxHealthGain = m3mgdExchange.(m3mgdAttrHealthGain)
+!mmm   
+!mmm   if not (maxHealthGain > 0 or maxEnduranceGain > 0)
 !mmm   
 !mmm     chat: /w "${user}" [**Lebens-/Ausdauergewinn eingeben**](~MacroSheet|applyHealingDataEntry)
 !mmm     exit script
 !mmm
 !mmm   end if 
+!mmm
+!mmm   set newHealth = m3mgdModifyHealth(maxHealthGain, cOwnID, cHealthAttr)
 !mmm   
-!mmm   set newHealth = m3mgdModifyHealth(m3mgdExchange.(m3mgdAttrHealthGain), cOwnID, cHealthAttr)
-!mmm   
-!mmm   set newEndurance = m3mgdModifyEndurance(m3mgdExchange.(m3mgdAttrEnduranceGain), cOwnID, cEnduranceAttr)
+!mmm   set prvEndurance = cOwnID.(cEnduranceAttr)
+!mmm   set newEndurance = m3mgdModifyEndurance(maxEnduranceGain, cOwnID, cEnduranceAttr)
+!mmm   set effEnduranceGain = newEndurance - prvEndurance
+!mmm   set enduranceHighlight = "normal"
+!mmm   if effEnduranceGain < maxEnduranceGain
+!mmm     set enduranceHighlight = "important"
+!mmm     if newEndurance == cOwnID.(cEnduranceAttr).max
+!mmm       set enduranceLog = "Auf AP.max begrenzt"
+!mmm     else if newEndurance <= m3mgdAttrCeiling(cOwnID, cEnduranceAttr)
+!mmm       set enduranceLog = "Auf " & m3mgdAttrCeiling(cOwnID, cEnduranceAttr) & " begrenzt"
+!mmm     else 
+!mmm       set enduranceLog = "Fehler? Grund für reduzierten AP-Gewinn unbekannt"
+!mmm     end if
+!mmm   end if
 !mmm
 !mmm   if newHealth <= 0 and timeToDie == undef
 !mmm     set timeToDie = "(unbekannt)"
@@ -41,8 +57,11 @@
 !mmm
 !mmm   combine chat
 !mmm     
-!mmm     chat: ${"&"}{template:default} 
-!mmm     chat: {{name=${cOwnID.name}}} 
+!mmm     chat: /w "${cOwnID.name}" ${"&"}{template:default} {{name=${m3mgdShapeMoji(cOwnID, cHealthAttr, cEnduranceAttr) & cOwnID.name}: Heil-/Ausdauereffekte}} 
+!mmm     
+!mmm     chat: {{Heileffekt=${highlight("+" & maxHealthGain, "normal")} **=>** ${newHealth} **LP**}}
+!mmm
+!mmm     chat: {{Ausdauereffekt=${highlight("+" & effEnduranceGain & "/" & maxEnduranceGain, enduranceHighlight, enduranceLog)} **=>** ${newEndurance} **AP**}}
 !mmm     
 !mmm     if newHealth < 0 and timeToDie < 0
 !mmm     
@@ -50,7 +69,6 @@
 !mmm     
 !mmm     else
 !mmm     
-!mmm       chat: {{Zustand=${newHealth} **LP** / ${newEndurance} **AP**}}
 !mmm       chat: {{${m3mgdHealthStatusLabel(cOwnID, cHealthAttr)}=${m3mgdHealthStatusEffectsDesc(cOwnID, cHealthAttr)}}}
 !mmm       chat: {{${m3mgdEnduranceStatusLabel(cOwnID, cEnduranceAttr)}=${m3mgdEnduranceStatusEffectsDesc(cOwnID, cEnduranceAttr)}}}
 !mmm     

--- a/examples/midgard/health/rest.mmm
+++ b/examples/midgard/health/rest.mmm
@@ -2,7 +2,7 @@
 !rem //
 %{MacroSheetLibrary|libMidgardFunctions}
 !mmm script
-!mmm   set scriptVersion = "rest 1.0.2 (2022-01-15)"
+!mmm   set scriptVersion = "rest 1.1.0 (2022-01-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -83,13 +83,27 @@
 !mmm   end if
 !mmm
 !mmm   set newHealth = m3mgdModifyHealth(healthGain, cOwnID, cHealthAttr)
+!mmm
+!mmm   set prvEndurance = cOwnID.(cEnduranceAttr)
 !mmm   set newEndurance = m3mgdModifyEndurance(enduranceGain, cOwnID, cEnduranceAttr)
+!mmm   set effEnduranceGain = newEndurance - prvEndurance
+!mmm   set enduranceHighlight = "normal"
+!mmm   if effEnduranceGain < enduranceGain
+!mmm     set enduranceHighlight = "important"
+!mmm     if newEndurance == cOwnID.(cEnduranceAttr).max
+!mmm       set enduranceTooltip = enduranceTooltip & ", auf AP.max begrenzt"
+!mmm     else if newEndurance <= m3mgdAttrCeiling(cOwnID, cEnduranceAttr)
+!mmm       set enduranceTooltip = enduranceTooltip & ", auf " & m3mgdAttrCeiling(cOwnID, cEnduranceAttr) & " begrenzt"
+!mmm     else 
+!mmm       set enduranceTooltip = enduranceTooltip & ", begrenzt, aber warum. Fehler?"
+!mmm     end if
+!mmm   end if
 !mmm
 !mmm   if newHealth <= 0 and timeToDie == undef
 !mmm     set timeToDie = "(unbekannt)"
 !mmm   end if
 !mmm
-!mmm   set enduranceGain = highlight("+" & enduranceGain, "normal", enduranceTooltip)
+!mmm   set enduranceGain = highlight("+" & effEnduranceGain & "/" & enduranceGain, enduranceHighlight, enduranceTooltip)
 !mmm   set healthGain = highlight("+" & healthGain, "normal", "über Mitternacht: " & midnightPassage)
 !mmm   
 !mmm   combine chat
@@ -97,7 +111,7 @@
 !mmm     chat: /w "${user}" ${"&"}{template:default} 
 !mmm     chat: {{name=${m3mgdShapeMoji(cOwnID, cHealthAttr, cEnduranceAttr) & cOwnID.name}: Erholung}} 
 !mmm     
-!mmm     chat: {{${restLog}=${enduranceGain} **AP** / ${healthGain} **LP**}}
+!mmm     chat: {{${restLog}=${healthGain} **=>** ${newHealth} **LP** / ${enduranceGain} **=>** ${newEndurance} **AP**}}
 !mmm
 !mmm     if newHealth < 0 and timeToDie < 0
 !mmm     
@@ -105,7 +119,6 @@
 !mmm     
 !mmm     else
 !mmm     
-!mmm       chat: {{Zustand=${newHealth} **LP** / ${newEndurance} **AP**}}
 !mmm       chat: {{${m3mgdHealthStatusLabel(cOwnID, cHealthAttr)}=${m3mgdHealthStatusEffectsDesc(cOwnID, cHealthAttr)}}}
 !mmm       chat: {{${m3mgdEnduranceStatusLabel(cOwnID, cEnduranceAttr)}=${m3mgdEnduranceStatusEffectsDesc(cOwnID, cEnduranceAttr)}}}
 !mmm     

--- a/examples/midgard/health/rest.mmm
+++ b/examples/midgard/health/rest.mmm
@@ -2,13 +2,15 @@
 !rem //
 %{MacroSheetLibrary|libMidgardFunctions}
 !mmm script
-!mmm   set scriptVersion = "rest 1.0.1 (2022-01-12)"
+!mmm   set scriptVersion = "rest 1.0.2 (2022-01-15)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
 !mmm     do whisperback("Midgard script " & scriptVersion)
 !mmm     exit script
 !mmm   end if
+!mmm
+%{MacroSheetLibrary|libMidgardGlobal}
 !mmm
 !mmm   if selected and sender.token_id ne selected
 !mmm     set customizable cOwnID = selected.token_id

--- a/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
@@ -130,7 +130,7 @@
 !rem 
 !rem // m3mgdSetAttrCeiling(tokenID, attrLabel, ceilingValue)
 !rem // 
-!rem //   
+!rem //   Places a temporary ceiling ceilingValue on tokenID attribute attrLabel and saves its value to be restored by m3mgdReleaseAttrCeiling().
 !rem //
 !mmm function m3mgdSetAttrCeiling(tokenID, attrLabel, ceilingValue)
 !mmm
@@ -181,7 +181,7 @@
 !rem
 !rem // m3mgdReleaseAttrCeiling(tokenID, attrLabel)
 !rem // 
-!rem //   
+!rem //   Releases a temporary ceiling placed on tokenID attribute attrLabel by m3mgdSetAttrCeiling() and restores the saved value for it.
 !rem //
 !mmm function m3mgdReleaseAttrCeiling(tokenID, attrLabel)
 !mmm   
@@ -199,8 +199,19 @@
 !mmm   
 !mmm   set storageAttrLabel = "m3mgd_token" & tokenID & "_" & attrLabel
 !mmm   if isunknown(dataExchangeID.(storageAttrLabel))
-!mmm     do whisperback("m3mgdReleaseAttrCeiling(): '" & dataExchangeID & "'.'" & storageAttrLabel & "' is no valid attribute.")
-!mmm     return false
+!rem     // Ugly workaround for endurance being stored in either "AP" or "bar2": try the other
+!mmm     if attrLabel eq "AP" or attrLabel eq "bar2"
+!mmm       if attrLabel eq "AP"
+!mmm         set attrLabel = "bar2"
+!mmm       else if attrLabel eq "bar2"
+!mmm         set attrLabel = "AP"
+!mmm       end if
+!mmm       set storageAttrLabel = "m3mgd_token" & tokenID & "_" & attrLabel
+!mmm     end if
+!mmm     if isunknown(dataExchangeID.(storageAttrLabel))
+!mmm       do whisperback("m3mgdReleaseAttrCeiling(): '" & dataExchangeID & "'.'" & storageAttrLabel & "' is no valid attribute.")
+!mmm       return false
+!mmm     end if
 !mmm   end if
 !mmm   
 !mmm   set originalValue = dataExchangeID.(storageAttrLabel)

--- a/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
@@ -127,7 +127,104 @@
 !mmm   return flushedCounter
 !mmm 
 !mmm end function
+!rem 
+!rem // m3mgdSetAttrCeiling(tokenID, attrLabel, ceilingValue)
 !rem // 
+!rem //   
+!rem //
+!mmm function m3mgdSetAttrCeiling(tokenID, attrLabel, ceilingValue)
+!mmm
+!mmm   set tokenID = m3mgdValidateOwnTokenID(tokenID)
+!mmm   if not tokenID
+!mmm     return false
+!mmm   end if
+!mmm   
+!mmm   if isdefault(attrLabel) or isunknown(tokenID.(attrLabel)) or isdenied(tokenID.(attrLabel))
+!mmm     do whisperback("m3mgdSetAttrCeiling(): '" & attrLabel & "' is no valid attribute for token '" & tokenID.name & "'")
+!mmm     return false
+!mmm   end if
+!mmm   
+!mmm   if isdefault(ceilingValue)
+!mmm     set ceilingValue = tokenID.(attrLabel)
+!mmm   else if ceilingValue > tokenID.(attrLabel)
+!mmm     return tokenID.(attrLabel)
+!mmm   end if
+!mmm   
+!mmm   set dataExchangeID = script.m3mgdExchange
+!mmm   
+!mmm   set storageAttrLabel = "m3mgd_token" & tokenID & "_" & attrLabel
+!mmm   if setattr(dataExchangeID, storageAttrLabel, tokenID.(attrLabel)) == tokenID.(attrLabel)
+!rem     // the above assumes that attrLabel always refers to numbers, not strings
+!mmm     
+!mmm     do whisperback("m3mgdSetAttrCeiling(): Safely stored current value for '" & tokenID.name & "'." & attrLabel & " (" & tokenID.(attrLabel) & ").")
+!mmm     
+!mmm     if setattr(tokenID, attrLabel, ceilingValue) == ceilingValue
+!mmm     
+!mmm       do whisperback("m3mgdSetAttrCeiling(): Set current value for '" & tokenID.name & "'." & attrLabel & " as " & ceilingValue)
+!mmm       return ceilingValue
+!mmm     
+!mmm     else 
+!mmm     
+!mmm       do whisperback("m3mgdSetAttrCeiling(): Failure changing '" & tokenID.name & "'." & attrLabel & " to '" & ceilingValue & "'")
+!mmm       return false
+!mmm
+!mmm     end if
+!mmm     
+!mmm   else
+!mmm   
+!mmm     do whisperback("m3mgdSetAttrCeiling(): Failure saving current value for '" & tokenID.name & "'." & attrLabel & " (" & tokenID.(attrLabel) & ").")
+!mmm     return false
+!mmm
+!mmm   end if
+!mmm   
+!mmm end function
+!rem
+!rem // m3mgdReleaseAttrCeiling(tokenID, attrLabel)
+!rem // 
+!rem //   
+!rem //
+!mmm function m3mgdReleaseAttrCeiling(tokenID, attrLabel)
+!mmm   
+!mmm   set tokenID = m3mgdValidateOwnTokenID(tokenID)
+!mmm   if not tokenID
+!mmm     return false
+!mmm   end if
+!mmm   
+!mmm   if isdefault(attrLabel) or isunknown(tokenID.(attrLabel)) or isdenied(tokenID.(attrLabel))
+!mmm     do whisperback("m3mgdReleaseAttrCeiling(): '" & attrLabel & "' is no valid attribute for token '" & tokenID.name & "'")
+!mmm     return false
+!mmm   end if
+!mmm   
+!mmm   set dataExchangeID = script.m3mgdExchange
+!mmm   
+!mmm   set storageAttrLabel = "m3mgd_token" & tokenID & "_" & attrLabel
+!mmm   if isunknown(dataExchangeID.(storageAttrLabel))
+!mmm     do whisperback("m3mgdReleaseAttrCeiling(): '" & dataExchangeID & "'.'" & storageAttrLabel & "' is no valid attribute.")
+!mmm     return false
+!mmm   end if
+!mmm   
+!mmm   set originalValue = dataExchangeID.(storageAttrLabel)
+!mmm   if originalValue < 0 or (tokenID.(attrLabel).max > 0 and originalValue > tokenID.(attrLabel).max)
+!mmm     do whisperback("m3mgdReleaseAttrCeiling(): stored value for '" & tokenID.name & "'.'" & attrLabel & "' is '" & originalValue & "' which is smaller than 0 or greater than max.")
+!mmm     return false
+!mmm   end if
+!mmm   
+!mmm   set ceilingValue = tokenID.(attrLabel)
+!mmm   
+!mmm   if setattr(tokenID, attrLabel, originalValue) == originalValue
+!mmm   
+!mmm     do whisperback("m3mgdReleaseAttrCeiling(): Reset '" & tokenID.name & "'.'" & attrLabel & "' to its pre-ceiling value '" & originalValue & "'.")
+!mmm     return originalValue
+!mmm
+!mmm   else
+!mmm   
+!mmm     do whisperback("m3mgdReleaseAttrCeiling(): Failure trying to reset '" & tokenID.name & "'.'" & attrLabel & "' to its pre-ceiling value '" & originalValue & "'.")
+!mmm     return false
+!mmm
+!mmm   end if
+!mmm   
+!mmm end function
+!rem 
 !rem // m3mgdEnduranceStatusLabel(tokenID, enduranceAttr)
 !rem // 
 !mmm function m3mgdEnduranceStatusLabel(tokenID, enduranceAttr)
@@ -406,7 +503,7 @@
 !mmm   end if
 !mmm   
 !mmm end function
-!rem // 
+!rem 
 !rem // m3mgdModifyHealth(offset, [tokenID], [healthAttr])
 !rem // 
 !rem // Modifies [tokenID's] or script.cOwnID's health by offset points. For a loss, offset is negative.
@@ -493,7 +590,24 @@
 !mmm     end if
 !mmm   
 !mmm     if setattr(tokenID, healthAttr, newHealth) == newHealth
-!mmm   
+!mmm       
+!mmm       set enduranceAttr = m3mgdValidateTokenAttribute(tokenID, default, "cEnduranceAttr")
+!mmm
+!mmm       if tokenID.(enduranceAttr).max > 0
+!mmm
+!mmm         if prvHealth > .5 * maxHealth and newHealth <= .5 * maxHealth
+!mmm         
+!mmm           set enduranceCeiling = round(.5 * tokenID.(enduranceAttr).max)
+!mmm           do m3mgdSetAttrCeiling(tokenID, enduranceAttr, enduranceCeiling)
+!mmm         
+!mmm         else if prvHealth <= .5 * maxHealth and newHealth > .5 * maxHealth
+!mmm         
+!mmm           do m3mgdReleaseAttrCeiling(tokenID, enduranceAttr)
+!mmm         
+!mmm         end if
+!mmm         
+!mmm       end if
+!mmm       
 !mmm       return newHealth
 !mmm     
 !mmm     else 

--- a/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
@@ -131,6 +131,7 @@
 !rem // m3mgdSetAttrCeiling(tokenID, attrLabel, ceilingValue)
 !rem // 
 !rem //   Places a temporary ceiling ceilingValue on tokenID attribute attrLabel and saves its value to be restored by m3mgdReleaseAttrCeiling().
+!rem //   WORKS ONLY WITH NUMERICAL ATTRIBUTE VALUES!
 !rem //
 !mmm function m3mgdSetAttrCeiling(tokenID, attrLabel, ceilingValue)
 !mmm
@@ -152,29 +153,84 @@
 !mmm   
 !mmm   set dataExchangeID = script.m3mgdExchange
 !mmm   
-!mmm   set storageAttrLabel = "m3mgd_token" & tokenID & "_" & attrLabel
-!mmm   if setattr(dataExchangeID, storageAttrLabel, tokenID.(attrLabel)) == tokenID.(attrLabel)
+!mmm   set storageAttrLabel = "m3mgd_tokenAttrCeiling" & tokenID & "_" & attrLabel
+!mmm   if setattr(dataExchangeID, storageAttrLabel, ceilingValue) == ceilingValue
 !rem     // the above assumes that attrLabel always refers to numbers, not strings
 !mmm     
-!mmm     do whisperback("m3mgdSetAttrCeiling(): Safely stored current value for '" & tokenID.name & "'." & attrLabel & " (" & tokenID.(attrLabel) & ").")
+!mmm     do whisperback("m3mgdSetAttrCeiling(): Stored '" & ceilingValue & "' as ceiling for '" & tokenID.name & "'.'" & attrLabel & "'.")
 !mmm     
 !mmm     if setattr(tokenID, attrLabel, ceilingValue) == ceilingValue
 !mmm     
-!mmm       do whisperback("m3mgdSetAttrCeiling(): Set current value for '" & tokenID.name & "'." & attrLabel & " as " & ceilingValue)
+!mmm       do whisperback("m3mgdSetAttrCeiling(): Set current value for '" & tokenID.name & "'.'" & attrLabel & "' as '" & ceilingValue & "'.")
 !mmm       return ceilingValue
 !mmm     
 !mmm     else 
 !mmm     
-!mmm       do whisperback("m3mgdSetAttrCeiling(): Failure changing '" & tokenID.name & "'." & attrLabel & " to '" & ceilingValue & "'")
+!mmm       do whisperback("m3mgdSetAttrCeiling(): Failure changing '" & tokenID.name & "'.'" & attrLabel & "' to '" & ceilingValue & "'.")
 !mmm       return false
 !mmm
 !mmm     end if
 !mmm     
 !mmm   else
 !mmm   
-!mmm     do whisperback("m3mgdSetAttrCeiling(): Failure saving current value for '" & tokenID.name & "'." & attrLabel & " (" & tokenID.(attrLabel) & ").")
+!mmm     do whisperback("m3mgdSetAttrCeiling(): Failure setting " & ceilingValue & " as ceiling for '" & tokenID.name & "'.'" & attrLabel & "'.")
 !mmm     return false
 !mmm
+!mmm   end if
+!mmm   
+!mmm end function
+!rem
+!rem // _m3mgdGetStoredAttr(dataExchangeID, tokenID, attrLabel, [flushStoredAttr])
+!rem // 
+!rem //   Pulls stored attribute attrLabel for tokenID from data exchange stack and guesses between alternative endurance attributes.
+!rem //   If flushStoredAttr == true, resets the stored attribute to "".
+!rem //
+!mmm function _m3mgdGetStoredAttr(dataExchangeID, tokenID, attrLabel, flushStoredAttr)
+!mmm   set paramAttrLabel = attrLabel
+!mmm   set storageAttrLabel = "m3mgd_tokenAttrCeiling" & tokenID & "_" & attrLabel
+!mmm   if isunknown(dataExchangeID.(storageAttrLabel))
+!rem     // Ugly guess for endurance being stored in either "AP" or "bar2": try the other
+!mmm     if attrLabel eq "AP" or attrLabel eq "bar2"
+!mmm       if attrLabel eq "AP"
+!mmm         set attrLabel = "bar2"
+!mmm       else if attrLabel eq "bar2"
+!mmm         set attrLabel = "AP"
+!mmm       end if
+!mmm       set storageAttrLabel = "m3mgd_tokenAttrCeiling" & tokenID & "_" & attrLabel
+!mmm     end if
+!mmm     if isunknown(dataExchangeID.(storageAttrLabel))
+!mmm       do whisperback("_m3mgdGetStoredAttr(): Found no valid stored attribute '" & paramAttrLabel &"' for token '" & tokenID.name & "'.")
+!mmm       return false
+!mmm     end if
+!mmm   end if
+!mmm   set payload = dataExchangeID.(storageAttrLabel)
+!mmm   if flushStoredAttr
+!mmm     do setattr(dataExchangeID, storageAttrLabel, "")
+!mmm   end if
+!mmm   return payload
+!mmm end function
+!rem
+!rem // m3mgdAttrCeiling(tokenID, attrLabel)
+!rem // 
+!rem //   Returns tokenID's temporary ceiling placed on attribute attrLabel, if present, otherwise false.
+!rem //
+!mmm function m3mgdAttrCeiling(tokenID, attrLabel)
+!mmm   
+!mmm   set tokenID = m3mgdValidateOwnTokenID(tokenID)
+!mmm   if not tokenID
+!mmm     return false
+!mmm   end if
+!mmm   
+!mmm   if isdefault(attrLabel) or isunknown(tokenID.(attrLabel)) or isdenied(tokenID.(attrLabel))
+!mmm     do whisperback("m3mgdAttrCeiling(): '" & attrLabel & "' is no valid attribute for token '" & tokenID.name & "'")
+!mmm     return false
+!mmm   end if
+!mmm
+!mmm   set attrCeiling = _m3mgdGetStoredAttr(script.m3mgdExchange, tokenID, attrLabel)
+!mmm   if attrCeiling > 0
+!mmm     return attrCeiling
+!mmm   else
+!mmm     return false
 !mmm   end if
 !mmm   
 !mmm end function
@@ -182,6 +238,7 @@
 !rem // m3mgdReleaseAttrCeiling(tokenID, attrLabel)
 !rem // 
 !rem //   Releases a temporary ceiling placed on tokenID attribute attrLabel by m3mgdSetAttrCeiling() and restores the saved value for it.
+!rem //   WORKS ONLY WITH NUMERICAL ATTRIBUTE VALUES!
 !rem //
 !mmm function m3mgdReleaseAttrCeiling(tokenID, attrLabel)
 !mmm   
@@ -197,42 +254,16 @@
 !mmm   
 !mmm   set dataExchangeID = script.m3mgdExchange
 !mmm   
-!mmm   set storageAttrLabel = "m3mgd_token" & tokenID & "_" & attrLabel
-!mmm   if isunknown(dataExchangeID.(storageAttrLabel))
-!rem     // Ugly workaround for endurance being stored in either "AP" or "bar2": try the other
-!mmm     if attrLabel eq "AP" or attrLabel eq "bar2"
-!mmm       if attrLabel eq "AP"
-!mmm         set attrLabel = "bar2"
-!mmm       else if attrLabel eq "bar2"
-!mmm         set attrLabel = "AP"
-!mmm       end if
-!mmm       set storageAttrLabel = "m3mgd_token" & tokenID & "_" & attrLabel
-!mmm     end if
-!mmm     if isunknown(dataExchangeID.(storageAttrLabel))
-!mmm       do whisperback("m3mgdReleaseAttrCeiling(): '" & dataExchangeID & "'.'" & storageAttrLabel & "' is no valid attribute.")
-!mmm       return false
-!mmm     end if
-!mmm   end if
+!mmm   set flushStoredAttr = true
+!mmm   set ceilingValue = _m3mgdGetStoredAttr(dataExchangeID, tokenID, attrLabel, flushStoredAttr)
+!mmm   if ceilingValue == false or ceilingValue < 0 or (tokenID.(attrLabel).max > 0 and ceilingValue > tokenID.(attrLabel).max)
 !mmm   
-!mmm   set originalValue = dataExchangeID.(storageAttrLabel)
-!mmm   if originalValue < 0 or (tokenID.(attrLabel).max > 0 and originalValue > tokenID.(attrLabel).max)
-!mmm     do whisperback("m3mgdReleaseAttrCeiling(): stored value for '" & tokenID.name & "'.'" & attrLabel & "' is '" & originalValue & "' which is smaller than 0 or greater than max.")
+!mmm     do whisperback("m3mgdReleaseAttrCeiling(): ceiling for '" & tokenID.name & "'.'" & attrLabel & "' is missing or invalid ('" & ceilingValue & "').")
 !mmm     return false
+!mmm   
 !mmm   end if
 !mmm   
-!mmm   set ceilingValue = tokenID.(attrLabel)
-!mmm   
-!mmm   if setattr(tokenID, attrLabel, originalValue) == originalValue
-!mmm   
-!mmm     do whisperback("m3mgdReleaseAttrCeiling(): Reset '" & tokenID.name & "'.'" & attrLabel & "' to its pre-ceiling value '" & originalValue & "'.")
-!mmm     return originalValue
-!mmm
-!mmm   else
-!mmm   
-!mmm     do whisperback("m3mgdReleaseAttrCeiling(): Failure trying to reset '" & tokenID.name & "'.'" & attrLabel & "' to its pre-ceiling value '" & originalValue & "'.")
-!mmm     return false
-!mmm
-!mmm   end if
+!mmm   return true
 !mmm   
 !mmm end function
 !rem 
@@ -281,6 +312,10 @@
 !mmm   if tokenID.status_green eq "shown"
 !mmm     
 !mmm     return "🟢 -4 auf alles, max. Last reduziert"
+!mmm     
+!mmm   else if tokenID.status_yellow eq "shown" and m3mgdAttrCeiling(tokenID, enduranceAttr)
+!mmm     
+!mmm     return "🟡 Ausdauer begrenzt auf 50%"
 !mmm     
 !mmm   else
 !mmm     
@@ -454,63 +489,70 @@
 !mmm     return false
 !mmm   end if
 !mmm   
-!rem   // Check if character is actually alive
-!mmm
-!mmm   set prvEndurance = tokenID.(enduranceAttr)
 !mmm   set maxEndurance = tokenID.(enduranceAttr).max
-!mmm   set newEndurance = false
+!mmm
+!rem   // Check if character is actually alive
 !mmm
 !mmm   if maxEndurance == 0
 !mmm
 !mmm     do whisperback(tokenID.token_name & " ist kein Wesen, das Ausdauerpunkte gewinnen oder verlieren kann (AP.max=0).")
 !mmm     return highlight(prvEndurance, "normal", "unverändert")
 !mmm
+!mmm   end if
+!mmm
+!mmm   set currentCeiling = m3mgdAttrCeiling(tokenID, enduranceAttr)
+!mmm   set prvEndurance = tokenID.(enduranceAttr)
+!mmm   set newEndurance = false
+!mmm
+!rem   // Process change of endurance and applicable consequences 
+!mmm
+!mmm   if currentCeiling and prvEndurance + offset > currentCeiling
+!mmm     set effOffset = highlight(currentCeiling - prvEndurance, "important", "begrenzt auf " & currentCeiling)
+!mmm   else if prvEndurance + offset > maxEndurance
+!mmm     set effOffset = highlight(maxEndurance - prvEndurance, "important", "begrenzt auf Maximum")
+!mmm   else if prvEndurance + offset <= 0
+!mmm     set effOffset = highlight(0 - prvEndurance, "bad", "begrenzt auf Minimum 0")
 !mmm   else
-!mmm
-!rem     // Process change of endurance and applicable consequences 
-!mmm
-!mmm     if prvEndurance + offset > maxEndurance
-!mmm       set effOffset = highlight(maxEndurance - prvEndurance, "important", "begrenzt auf Maximum")
-!mmm     else if prvEndurance + offset <= 0
-!mmm       set effOffset = highlight(0 - prvEndurance, "bad", "begrenzt auf Minimum 0")
-!mmm     else
-!mmm       set effOffset = highlight(offset, "normal")
-!mmm     end if 
+!mmm     set effOffset = highlight(offset, "normal")
+!mmm   end if 
 !mmm   
-!mmm     set newEndurance = prvEndurance + effOffset
+!mmm   set newEndurance = prvEndurance + effOffset
 !mmm   
-!mmm     if effOffset >= 0
-!mmm       set effOffset = "+" & effOffset
-!mmm     end if
+!mmm   if effOffset >= 0
+!mmm     set effOffset = "+" & effOffset
+!mmm   end if
 !mmm   
-!mmm     if newEndurance == maxEndurance
+!mmm   if newEndurance == maxEndurance
 !mmm   
-!mmm       set newEndurance = highlight(newEndurance, "good", "Bin sowas von topfit! (= " & prvEndurance & effOffset & ")")
-!mmm       do setattr(tokenID, "status_green", false)
+!mmm     set newEndurance = highlight(newEndurance, "good", "Bin sowas von topfit! (= " & prvEndurance & effOffset & ")")
+!mmm     do setattr(tokenID, "status_green", false)
 !mmm   
-!mmm     else if newEndurance == 0
+!mmm   else if currentCeiling and newEndurance == currentCeiling and newEndurance > 0
 !mmm   
-!mmm       set newEndurance = highlight(newEndurance, "bad", "🟢 (= " & prvEndurance & effOffset & ")")
-!mmm       do setattr(tokenID, "status_green", true)
+!mmm     set newEndurance = highlight(newEndurance, "important", "🟡 (= " & prvEndurance & effOffset & ")")
+!mmm     do setattr(tokenID, "status_green", false)
 !mmm   
-!mmm     else
+!mmm   else if newEndurance == 0
 !mmm   
-!mmm       set newEndurance = highlight(newEndurance, "normal", "Och, das bisschen Schweiß! (= " & prvEndurance & effOffset & ")")
-!mmm       do setattr(tokenID, "status_green", false)
+!mmm     set newEndurance = highlight(newEndurance, "bad", "🟢 (= " & prvEndurance & effOffset & ")")
+!mmm     do setattr(tokenID, "status_green", true)
 !mmm   
-!mmm     end if
+!mmm   else
 !mmm   
-!mmm     if setattr(tokenID, enduranceAttr, newEndurance) == newEndurance
+!mmm     set newEndurance = highlight(newEndurance, "normal", "Och, das bisschen Schweiß! (= " & prvEndurance & effOffset & ")")
+!mmm     do setattr(tokenID, "status_green", false)
 !mmm   
-!mmm       return newEndurance
+!mmm   end if
+!mmm   
+!mmm   if setattr(tokenID, enduranceAttr, newEndurance) == newEndurance
+!mmm   
+!mmm     return newEndurance
 !mmm     
-!mmm     else 
+!mmm   else 
 !mmm     
-!mmm       do whisperback("Error writing changes to endurance (" & effOffset & ") into " & tokenID & "." & enduranceAttr)
-!mmm       return false
+!mmm     do whisperback("Error writing changes to endurance (" & effOffset & ") into " & tokenID & "." & enduranceAttr)
+!mmm     return false
 !mmm     
-!mmm     end if
-!mmm   
 !mmm   end if
 !mmm   
 !mmm end function


### PR DESCRIPTION
Here's a very basic rule we had to annoyingly implement manually all along, even though it is almost made for computers to track: once a character loses 50% of health, their endurance is capped at 50%, as well -- until their health exceeds 50% again, at which point their endurance is able to exceed the temporary ceiling again. Under the ceiling, endurance-boosting potions or a full nights' rest can only have limited effects -- up to 50% of max endurance, now more.

The suite of scripts manipulating health and endurance now implements this rule in hopefully all relevant cases for combat situations.

Details: https://github.com/phylll/mychs-macro-magic/issues/33