### PR TITLE
Small fixes from last night's session

### DIFF
--- a/examples/midgard/defense/defendFrostball.mmm
+++ b/examples/midgard/defense/defendFrostball.mmm
@@ -1,7 +1,7 @@
 !rem // Defends against Midgard's Frostball spell, as defined in Arkanum:86
 !rem //
 !mmm script
-!mmm   set scriptVersion = "defendFrostball 1.3.3 (2022-01-24)"
+!mmm   set scriptVersion = "defendFrostball 1.3.4 (2022-01-26)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -123,5 +123,10 @@
 !rem
 !rem   // Output data table using data table execution code from library
 !mmm   do m3mgdDefenseDataTable()
-!mmm
+!mmm   
+!rem   // Special effects
+!mmm   if effHealthLoss > 0 or effEnduranceLoss > 0
+!mmm     do m3mgdInjuryFX(cOwnID, effHealthLoss / maxHealth, effEnduranceLoss / cOwnID.(cEnduranceAttr).max)
+!mmm   end if
+!mmm   
 !mmm end script

--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "defense 1.12.1 (2022-01-24)"
+!mmm   set scriptVersion = "defense 1.12.2 (2022-01-26)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -332,4 +332,10 @@
 !mmm     chat: /w "${cOwnID.name}" ***Nicht vergessen: PP für ${cWeaponLabel} einstecken!*** [x](https://media.giphy.com/media/hKafco7mFwBioBxqFT/giphy.gif)
 !mmm     chat: /w GM               ***Nicht vergessen: PP für ${cWeaponLabel} einstecken!*** [x](https://media.giphy.com/media/hKafco7mFwBioBxqFT/giphy.gif)
 !mmm   end if
+!mmm   
+!rem   // Special effects
+!mmm   if effHealthLoss > 0 or effEnduranceLoss > 0
+!mmm     do m3mgdInjuryFX(cOwnID, effHealthLoss / maxHealth, effEnduranceLoss / cOwnID.(cEnduranceAttr).max)
+!mmm   end if
+!mmm   
 !mmm end script

--- a/examples/midgard/libMidgardGlobal/initGameGlobals.mmm
+++ b/examples/midgard/libMidgardGlobal/initGameGlobals.mmm
@@ -99,4 +99,7 @@
 !mmm   
 !mmm   publish to game: count
 !mmm   
+!mmm   set sender = "MacroSheetLibrary"
+!mmm   chat: /me (${scriptVersion}) loaded.
+!mmm   
 !mmm end script

--- a/examples/midgard/libMidgardGlobal/initGameGlobals.mmm
+++ b/examples/midgard/libMidgardGlobal/initGameGlobals.mmm
@@ -92,7 +92,7 @@
 !mmm   publish to game: m3mgdShapeMoji
 !mmm   publish to game: m3mgdExchangeStoreAttack, m3mgdExchangeStoreHealthBoost, m3mgdExchangeStoreEnduranceBoost
 !mmm   publish to game: m3mgdListDefenseWeapons, m3mgdListMeleeAttackWeapons, m3mgdListRangedAttackWeapons
-!mmm   publish to game: m3mgdSendDefenseChatButtons, m3mgdDefenseDataTable
+!mmm   publish to game: m3mgdSendDefenseChatButtons, m3mgdDefenseDataTable, m3mgdInjuryFX
 !mmm   publish to game: m3mgdProcessAttackXP
 !mmm   
 %{MacroSheetLibrary|libBasics}

--- a/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
@@ -947,7 +947,8 @@
 !rem //   Whispers chat buttons to foeID's player to launch defense
 !rem //
 !mmm function m3mgdSendDefenseChatButtons(foeID)
-!mmm   chat: /w "${foeID.character_name}" ${"&"}{template:default} {{[**Abwehr offen**](~MacroSheet|defense)=[**Abwehr geheim**](~MacroSheet|npcDefense)}}
+!mmm   set sender = script.sender
+!mmm   chat: /w "${foeID.character_name}" ${"&"}{template:default} {{name=Abwehr mit Standardwaffe}} {{[**Abwehr offen**](~MacroSheet|defense)=[**Abwehr geheim**](~MacroSheet|npcDefense)}}
 !mmm end function
 !rem
 !rem // m3mgdProcessAttackXP(attackType, attackDamageRoll, [attackerID], [targetID])
@@ -1032,6 +1033,8 @@
 !mmm   set attackDamage = highlight(script.m3mgdExchange.(m3mgdAttrAttackDamage), "info", script.m3mgdExchange.(m3mgdAttrAttackType))
 !mmm   set effEnduranceLoss = highlight(script.effEnduranceLoss, "normal")
 !mmm   set effHealthLoss = highlight(script.effHealthLoss, "normal")
+!mmm
+!mmm   set sender = script.sender
 !rem
 !rem   // Build data table
 !rem

--- a/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
@@ -1080,14 +1080,6 @@
 !mmm       chat: {{Schaden=**${effHealthLoss}&nbsp;LP&nbsp;/&nbsp;${effEnduranceLoss}&nbsp;AP**}}
 !mmm     end if
 !mmm
-!mmm     if effHealthLoss >= .2 * script.maxHealth
-!mmm       do spawnfx("nova-blood", script.cOwnID.left, script.cOwnID.top)
-!mmm     else if effHealthLoss > 0
-!mmm       do spawnfx("bubbling-blood", script.cOwnID.left, script.cOwnID.top)
-!mmm     else if effEnduranceLoss > 0
-!mmm       do spawnfx("bubbling-water", script.cOwnID.left, script.cOwnID.top)
-!mmm     end if
-!mmm
 !mmm     if script.criticalAttack == true and script.m3mgdExchange.(m3mgdAttrAttackType) eq "magic"
 !mmm       chat: {{Kritischer Zaubererfolg=Zauber wirkt **doppelt so stark** oder ist **halb so teuer**: Nach Wahl des Zauberers umsetzen.}}
 !mmm     else if script.criticalAttack == true
@@ -1110,4 +1102,23 @@
 !mmm
 !mmm   return true
 !mmm   
+!mmm end function
+!rem
+!rem // m3mgdInjuryFX(tokenID, relativeHealthLoss, relativeEnduranceLoss)
+!rem //
+!mmm function m3mgdInjuryFX(tokenID, relativeHealthLoss, relativeEnduranceLoss)
+!mmm
+!mmm   if relativeHealthLoss >= .2
+!mmm     set fx = "nova-blood"
+!mmm   else if relativeHealthLoss > 0
+!mmm     set fx = "bubbling-blood"
+!mmm   else if relativeEnduranceLoss > 0
+!mmm     set fx = "bubbling-water"
+!mmm   end if
+!mmm   if fx ne ""
+!mmm     do delay(3)
+!mmm     do spawnfx(fx, tokenID.left, tokenID.top)
+!mmm     do delay(1)
+!mmm     do spawnfx(fx, tokenID.left, tokenID.top)
+!mmm   end if
 !mmm end function

--- a/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgardFunctions.mmm
@@ -846,7 +846,6 @@
 !mmm function m3mgdExchangeStoreHealthBoost(healthGain, targetID)
 !mmm   
 !mmm   set dataExchangeID = script.m3mgdExchange
-!mmm   do m3mgdFlushExchange(dataExchangeID)
 !mmm
 !mmm   if healthGain <= 0
 !mmm     do whisperback("Storing health gain <=0 makes no sense.")
@@ -873,7 +872,6 @@
 !mmm function m3mgdExchangeStoreEnduranceBoost(enduranceGain, targetID)
 !mmm   
 !mmm   set dataExchangeID = script.m3mgdExchange
-!mmm   do m3mgdFlushExchange(dataExchangeID)
 !mmm
 !mmm   if enduranceGain <= 0
 !mmm     do whisperback("Storing endurance gain <=0 makes no sense.")

--- a/examples/midgard/rangedAttack/waterWalkerBlastEffect.mmm
+++ b/examples/midgard/rangedAttack/waterWalkerBlastEffect.mmm
@@ -1,7 +1,7 @@
 !rem // waterWalkerBlastEffect
 !rem
 !mmm script
-!mmm   set scriptVersion = "1.1.1 (2022-01-24)"
+!mmm   set scriptVersion = "1.1.2 (2022-01-27)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -54,7 +54,7 @@
 !mmm       set blastBearing = m3mgdGetTokenDirection(cWeaponWielder, foe)
 !mmm       do setattr(foe, "left", foe.left - (sin(blastBearing) * blastDistance / distscale()))
 !mmm       do setattr(foe, "top", foe.top + (cos(blastBearing) * blastDistance / distscale()))
-!mmm       chat: Der harte Wasserstrahl spült ${foe.name} ${blastDistance} Meter nach hinten und auf den Hosenboden: PW:St(${foe.St}) = ${stRoll} / Strahlstärke: ${blastDistance}
+!mmm       chat: Der harte Wasserstrahl spült ${foe.name} ${blastDistance} Meter nach hinten und auf den Hosenboden: PW:St(${foe.St}) = ${stRoll} / Strahlstärke: ${blastDistance} [x](https://media.giphy.com/media/MZSBHPaa0Y7FMelPtN/giphy.gif)
 !mmm     end if
 !mmm   end if
 !mmm   


### PR DESCRIPTION
- All public chat outputs from global functions now impersonate the calling script's sender (no more weird changes of who appears to be speaking between different output sections from the same script)
- `initGameGlobals` has a useful status message now
- Injury-related visual special effects are now slightly delayed and duplicated to give players a better chance of enjoying them (https://github.com/phylll/mychs-macro-magic/issues/41)
- Bugfix: data exchange had been getting flushed one too many times, deleting half the payload in healing situations
- Magic rune blade Waterwalker has a GIF now for the players' merriment