### PR TITLE
Implemented #76 multiple persistent effects, along with quite a few small bugfixes in critical effects handling

### DIFF
--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "defense 2.0.0-pre (2022-05-07)"
+!mmm   set scriptVersion = "defense 2.0.0-pre (2024-02-27)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -171,7 +171,7 @@
 !mmm     for activeMod in m3mgdActiveStatusModifiers(cOwnID, "defense")
 !mmm       set autoModifiers = autoModifiers + activeMod.rollModifiers.defense
 !mmm       set modifierLog = modifierLog & " {{" & activeMod.label & "=" & sign(activeMod.rollModifiers.defense, "display") & "}} "
-!mmm       set modifierTooltip = modifierTooltip & " " & activeMod.label & "&nbsp;&nbsp;&nbsp;" & activeMod.rollModifiers.defense & " "
+!mmm       set modifierTooltip = modifierTooltip & " " & activeMod.label & "&nbsp;&nbsp;&nbsp;" & sign(activeMod.rollModifiers.defense, "display") & " "
 !mmm     end for
 !rem     // 2. Dropdown prompt: Focused defense, surprise (taken from prior user input customize block)
 !mmm     if cSemiManualModifiers == 4 
@@ -327,7 +327,7 @@
 !rem   // If present, reduce counters for defense-specific modifier effects
 !mmm   set endOfActionSummary = m3mgdUpdatePersistentEffectsCounters(cOwnID, "defense")
 !mmm   if endOfActionSummary
-!mmm     set modifierLog = modifierLog & " {{ Zähler=" & endOfActionSummary & " }}"
+!mmm     set modifierLog = modifierLog & " {{ Abwehrzähler=" & endOfActionSummary & " }}"
 !mmm   end if
 !mmm
 !rem   // Output modifier log and PP reminder

--- a/examples/midgard/libMidgardGlobal/criticalEffectsDebugFlush.mmm
+++ b/examples/midgard/libMidgardGlobal/criticalEffectsDebugFlush.mmm
@@ -1,8 +1,8 @@
 !mmm script
-!mmm   chat: Flushing Yorric's and Druide 2's active effects attributes
+!mmm   chat: Flushing Yorric's and Titos' active effects attributes
 !mmm   set effectsDB = deserialize(m3mgdExchange.m3mgdActivePersistentEffects)
-!mmm   for tokenID in "Yorric MacRathgar".token_id, "-M_a1Zy8w8jDCc0qt172"
-!mmm     set effectsDB = { effectsDB where ...key ne tokenID }
+!mmm   for tokenID in "Yorric MacRathgar".token_id, "Titos Panathos".token_id
+!mmm     set effectsDB = { effectsDB... where ...key ne tokenID }
 !mmm   end for
 !mmm   do setattr(m3mgdExchange, "m3mgdActivePersistentEffects", serialize(effectsDB))
 !mmm   chat: done.

--- a/examples/midgard/libMidgardGlobal/criticalEffectsTableBuilder.mmm
+++ b/examples/midgard/libMidgardGlobal/criticalEffectsTableBuilder.mmm
@@ -1,3 +1,5 @@
+!rem // Critical effects tables
+!rem // Last revised: 2024-02-27
 !mmm function m3mgdBuildCriticalEffectsTables()
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
@@ -238,7 +240,7 @@
 !mmm     set entryData = { entryData, desc: 'Du stolperst und musst die nächste Runde aussetzen um dich neu zu sammeln. Angreifer bekommen +4 auf Ihren nächsten Angriff. Keine negative Auswirkung auf Deine Verteidigung in der nächsten Runde. Bei misslungenem Prüfwurf auf Geschicklichkeit schlägst Du mit dem Kopf so unglücklich auf, dass Du für 1W6 Runden ohnmächtig wirst. Träger eines Helms bekommen +4 auf ihren Prüfwurf.' }
 !mmm     set entryData = { entryData, userInput: { xhelmetworn: '?' & '{Trägst du einen Helm?|Ja,4|Nein,0}' } }
 !mmm     set entryData = { entryData, immediate: '!mmm do m3mgdRollChanceEffect(myID, "Gs", "1d100", xhelmetworn, "!mmm do setattr(myID, \'status_pummeled\', true)", { expiry: { count: "1d6", type: "round" }, marker: "status_pummeled" })' } 
-!mmm     set entryData = { entryData, persistent: { focus: "foe", expiry: { count: 1, type: "round" }, rollModifiers: { meleeAttack: +4 } } }
+!mmm     set entryData = { entryData, persistent: ({ expiry: { count: 1, type: "round" }, noAttack: true }, { focus: "foe", expiry: { count: 1, type: "round" }, rollModifiers: { meleeAttack: +4 } }) }
 !mmm     set table = { table, (entryID): entryData }
 !mmm
 !mmm     set entryID = 23
@@ -286,7 +288,7 @@
 !mmm     set entryData = { weight: 10, label: '⚀ Kritischer Fehler beim Nahkampf-Angriff', url: '' }
 !mmm     set entryData = { entryData, desc: 'Du rempelst versehentlich einen Freund auf einem Nachbarfeld an. Dieser bekommt in der nächsten Runde -2 auf seinen EW:Angriff. Du selber bist dadurch etwas orientierungslos und musst eine Runde aussetzen. Es gibt in der nächsten Runde jedoch keinen Vorteil für Deinen Gegner und keinen Nachteil für Deine Verteidigung.' }
 !mmm     set entryData = { entryData, userInput: { xtarget: '"@' & '{target|Wen hast du angerempelt?|token_id}"' } }
-!mmm     set entryData = { entryData, immediate: '!mmm do m3mgdStoreCriticalEffect(xtarget, { expiry: { count: 1, type: "round" }, rollModifiers: { meleeAttack: -2 } })' }
+!mmm     set entryData = { entryData, immediate: '!mmm do m3mgdStorePersistentEffect(xtarget, { label: "⚀ Angerempelt (kritischer Fehler des Gefährten)", desc: "-2 auf EW:Angriff in der nächsten Runde", effect: { expiry: { count: 1, type: "round" }, rollModifiers: { meleeAttack: -2 } } })' }
 !mmm     set entryData = { entryData, persistent: { expiry: { count: 1, type: "round" }, noAttack: true } }
 !mmm     set table = { table, (entryID): entryData }
 !mmm
@@ -392,7 +394,7 @@
 !mmm     set entryData = { weight: 5, label: '⚅ Schwerer Kopftreffer', url: '' }
 !mmm     set entryData = { entryData, desc: 'Helmlose Opfer verlieren zusätzlich zum normalen Schaden 1W3 LP und AP. Der Getroffene verliert für 2W6 Runden das Bewusstsein (1W6 Runden für Helmträger) und ist 30 min lang (15 Minuten für Helmträger) benommen und handlungsunfähig. Übersteigen die LP-Verluste ein Drittel seines LP-Maximums, fällt ein helmloses Opfer mit 20% in ein Koma.' }
 !mmm     set entryData = { entryData, userInput: { xdmg: '"?' & '{Trägt das Opfer Helm?|Ja,0|Nein,1d3}"' } }
-!mmm     set entryData = { entryData, immediate: ('!mmm do m3mgdProcessInjury(foeID, xdmg, "*", false)', '!mmm do setattr(foeID, "status_pummeled", true)', '!mmm do m3mgdStoreCriticalEffect(foeID, { expiry: { count: ((xdmg + 0 ne 0)+1)&"d6", type: "round" }, marker: "status_pummeled" })') }
+!mmm     set entryData = { entryData, immediate: ('!mmm do m3mgdProcessInjury(foeID, xdmg, "*", false)', '!mmm do setattr(foeID, "status_pummeled", true)', '!mmm do m3mgdStorePersistentEffect(foeID, { label: "⚀ Schwerer Kopftreffer", desc: "Bewusstlos", effect: { expiry: { count: ((xdmg + 0 ne 0)+1)&"d6", type: "round" }, marker: "status_pummeled" } })') }
 !mmm     set table = { table, (entryID): entryData }
 !mmm
 !mmm     set entryID = 89
@@ -427,7 +429,7 @@
 !mmm     set entryData = { weight: 1, label: '⚅ Schwere Schädelverletzung', url: '' }
 !mmm     set entryData = { entryData, desc: 'Helmlose Opfer verlieren zusätzlich zum normalen Schaden 1W6 LP und AP. Der Getroffene verliert für 2W6 Runden das Bewusstsein (1W6 Runden für Helmträger) und ist 30 min lang (15 Minuten für Helmträger) benommen und handlungsunfähig. Übersteigen die LP-Verluste ein Drittel seines LP-Maximums, fällt ein helmloses Opfer mit 20% in ein Koma und seine Intelligenz sinkt durch Hirnschäden dauerhaft um ein Zehntel (mindestens aber um 1).' }
 !mmm     set entryData = { entryData, userInput: { xdmg: '"?' & '{Trägt das Opfer Helm?|Ja,0|Nein,1d6}"' } }
-!mmm     set entryData = { entryData, immediate: ('!mmm script', '!mmm do m3mgdProcessInjury(foeID, xdmg, "*", false)', '!mmm do setattr(foeID, "status_pummeled", true)', '!mmm do m3mgdStoreCriticalEffect(foeID, { expiry: { count: ((xdmg + 0 ne 0)+1) & "d6", type: "round" }, marker: "status_pummeled" })', '!mmm do setattr(foeID, "status_ninja_mask", true)', '!mmm end script') }
+!mmm     set entryData = { entryData, immediate: ('!mmm script', '!mmm do m3mgdProcessInjury(foeID, xdmg, "*", false)', '!mmm do setattr(foeID, "status_pummeled", true)', '!mmm do m3mgdStorePersistentEffect(foeID, { label: "⚀ Schwere Schädelverletzung", desc: "Bewusstlos", effect: { expiry: { count: ((xdmg + 0 ne 0)+1) & "d6", type: "round" }, marker: "status_pummeled" } })', '!mmm do setattr(foeID, "status_ninja_mask", true)', '!mmm end script') }
 !mmm     set table = { table, (entryID): entryData }
 !mmm
 !mmm     set entryID = 99

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgard()
 !mmm   
-!mmm   set libVersion = "libMidgard v1.4.0-pre (2024-02-14-2130)"
+!mmm   set libVersion = "libMidgard v1.4.0-pre (2024-02-27)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
@@ -260,11 +260,11 @@
 !mmm   end for
 !mmm end function
 !rem
-!rem // m3mgdRollChanceEffect(tokenID, attribute, rollTemplate, rollModifiers, immediateEffect, [persistentEffect])
+!rem // m3mgdRollChanceEffect(tokenID, attribute, rollTemplate, rollModifiers, immediateEffect, [persistentEffects])
 !rem // 
-!rem //   If a rollTemplate roll exceeds tokenID.(attribute)+rollModifiers, executes Roll20 chat code immediateEffect and stores persistentEffect.
+!rem //   If a rollTemplate roll exceeds tokenID.(attribute)+rollModifiers, executes Roll20 chat code immediateEffect and stores persistentEffects.
 !rem // 
-!mmm function m3mgdRollChanceEffect(tokenID, attribute, rollTemplate, rollModifiers, immediateEffect, persistentEffect)
+!mmm function m3mgdRollChanceEffect(tokenID, attribute, rollTemplate, rollModifiers, immediateEffect, persistentEffects)
 !mmm
 !rem   // Stop condition if recursion ends up here without a tokenID
 !mmm   if isdefault(tokenID) or isunknown(tokenID)
@@ -292,8 +292,10 @@
 !mmm
 !mmm   if rollResult > tokenID.(attribute)
 !mmm     do _m3mgdExecuteCode(immediateEffect, tokenID)
-!mmm     if not isdefault(persistentEffect)
-!mmm       do m3mgdStorePersistentEffect(tokenID, { label: currentEffect.label, desc: currentEffect.desc, effect: persistentEffect })
+!mmm     if not isdefault(persistentEffects)
+!mmm       for pE in persistentEffects
+!mmm         do m3mgdStorePersistentEffect(tokenID, { label: currentEffect.label, desc: currentEffect.desc, effect: pE })
+!mmm       end for
 !mmm     end if
 !mmm   end if
 !mmm
@@ -494,7 +496,7 @@
 !mmm   if not tokenID
 !mmm     return false
 !mmm   end if
-!mmm   if not m3mgdHasActivePersistentEffects(tokenID)
+!mmm   if m3mgdHasActivePersistentEffects(tokenID)
 !mmm     set tokenActiveEffectsList = m3mgdGetActivePersistentEffects(tokenID)
 !mmm   end if
 !mmm 
@@ -1764,14 +1766,17 @@
 !rem //   persistentEffect = { 
 !rem //     label: "string", 
 !rem //     desc: "string", 
-!rem //     effect: { 
+!rem //     effect: { }
+!rem //   }
+!rem //   The effect attribute can either look like this:
+!rem //     effect: {
 !rem //       expiry: { type: "[round|attack|defense]", count: integer or dice formula ("1d6+3") },   // plus one or more of the following:
 !rem //       [rollModifiers: { [attack|meleeAttack|rangedAttack|defense]: integer },]
 !rem //       [noAttack|noDefense|noFocusedDefense: true,]
 !rem //       [cappedAttribute: "(valid attribute for tokenID)",]
 !rem //       [marker: "(valid status marker for tokenID)"]
 !rem //     }
-!rem //   }
+!rem //   Or it contains a series of the previously described structs, labeled with a key.
 !rem //   Returns the stored persistentEffect struct, updated by whatever dice thrown to resolve effect.expiry.count.
 !rem //
 !mmm function m3mgdStorePersistentEffect(tokenID, persistentEffect)
@@ -1814,7 +1819,7 @@
 !rem //     desc: ["string" | { "context 1": "string", "context 2": "string", ...}],
 !rem //     [userInput]: {}, // key:value pairs defining the two sides of an MMM set statement, e.g. "myVar": "@" & "{Is the sky blue?|Yes,1|No,0}", made available to the code stored as immediate
 !rem //     [immediate]: *,  // Could be a string (Roll20 chat command), a list of strings, or a struct that maps context identifiers (keys, as in desc above) to either strings or list of strings holding chat commands (values)
-!rem //     [persistent]: {} // struct as documented in m3mgdStorePersistentEffect()
+!rem //     [persistent]: ({}, {}) // [list of] structs as documented in m3mgdStorePersistentEffect()
 !rem //   }
 !rem //
 !mmm function m3mgdExecuteCriticalEffect(tokenID, tableName, rollResult, context, foeID)
@@ -1848,20 +1853,34 @@
 !mmm       set codeLines = criticalEffect.immediate
 !mmm     end if
 !mmm     
-!mmm     if criticalEffect.persistent.expiry
-!mmm       set persistentEffectsList = criticalEffect.persistent
-!mmm     else if criticalEffect.persistent.(context).expiry or (criticalEffect.persistent.(context)[0].expiry and criticalEffect.persistent.(context)[1].expiry)
-!mmm       set persistentEffectsList = criticalEffect.persistent.(context)
+!rem     // Filter (list of) persistent effects for those applicable to the given context
+!mmm     for pE in criticalEffect.persistent
+!mmm       if pE.expiry
+!mmm         set persistentEffectsList = persistentEffectsList, pE
+!mmm       else if pE.(context).expiry or (pE.(context)[0].expiry and pE.(context)[1].expiry)
+!mmm         set persistentEffectsList = persistentEffectsList, pE.(context)
+!mmm       end if
+!mmm     end for
+!mmm 
+!rem     // Wrap and store each applicable persistent effect
+!mmm     if persistentEffectsList > 1
+!mmm       set pEcounter = 1
 !mmm     end if
-!mmm     for persistentEffect in persistentEffectsList
-!mmm       set persistentEffect = { effect: persistentEffect, label: criticalEffect.label, desc: descText }
-!mmm       if persistentEffect.effect.focus eq "foe"
+!mmm     for applicablePersistentEffect in persistentEffectsList
+!mmm       set completePersistentEffect = { effect: applicablePersistentEffect, label: criticalEffect.label, desc: descText }
+!mmm       if completePersistentEffect.effect.focus eq "foe"
 !mmm         set targetID = foeID
-!mmm       else if persistentEffect
+!mmm       else if completePersistentEffect
 !mmm         set targetID = tokenID
 !mmm       end if
-!mmm       set persistentEffect = m3mgdStorePersistentEffect(targetID, persistentEffect)
-!mmm       chat: {\{ ${persistentEffect.label}=${persistentEffect.effect} }\}
+!mmm       set completePersistentEffect = m3mgdStorePersistentEffect(targetID, completePersistentEffect)
+!mmm       if pEcounter
+!mmm         set pEcounterLabel = "(Effekt #" & pEcounter & ")"
+!mmm       end if
+!mmm       chat: {\{ ${completePersistentEffect.label} ${pEcounterLabel}=${completePersistentEffect.effect} }\}
+!mmm       if pEcounter
+!mmm         set pEcounter = pEcounter + 1
+!mmm       end if
 !mmm     end for
 !mmm
 !mmm   end combine

--- a/examples/midgard/meleeAttack/meleeAttack.mmm
+++ b/examples/midgard/meleeAttack/meleeAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Melee Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "meleeAttack v2.0.0-pre (2022-04-14)"
+!mmm   set scriptVersion = "meleeAttack v2.0.0-pre (2024-02-27)"
 !rem
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -143,7 +143,7 @@
 !mmm   for activeMod in m3mgdActiveStatusModifiers(cOwnID, "meleeAttack")
 !mmm     set autoModifiers = autoModifiers + activeMod.rollModifiers.meleeAttack
 !mmm     set modifierLog = modifierLog & " {{" & activeMod.label & "=" & sign(activeMod.rollModifiers.meleeAttack, "display") & "}} "
-!mmm     set modifierTooltip = modifierTooltip & " " & activeMod.label & "&nbsp;&nbsp;&nbsp;" & activeMod.rollModifiers.meleeAttack & " "
+!mmm     set modifierTooltip = modifierTooltip & " " & activeMod.label & "&nbsp;&nbsp;&nbsp;" & sign(activeMod.rollModifiers.meleeAttack, "display") & " "
 !mmm   end for
 !rem   // 2. Target exhausted
 !mmm   if m3mgdIsExhausted(cTargetID)
@@ -348,7 +348,7 @@
 !rem   // If present, reduce counters for attack-specific modifier effects
 !mmm   set endOfActionSummary = m3mgdUpdatePersistentEffectsCounters(cOwnID, "attack")
 !mmm   if endOfActionSummary
-!mmm     set modifierLog = modifierLog & " {{ Zähler=" & endOfActionSummary & " }}"
+!mmm     set modifierLog = modifierLog & " {{ Angriffszähler=" & endOfActionSummary & " }}"
 !mmm   end if
 !mmm
 !mmm   if modifierLog ne "{{Boni/Mali=keine}}"

--- a/examples/midgard/rangedAttack/rangedAttack.mmm
+++ b/examples/midgard/rangedAttack/rangedAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Ranged Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "2.0.0-pre (2022-04-14)"
+!mmm   set scriptVersion = "2.0.0-pre (2024-02-27)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -275,7 +275,7 @@
 !mmm   for activeMod in m3mgdActiveStatusModifiers(cOwnID, "rangedAttack")
 !mmm     set autoModifiers = autoModifiers + activeMod.rollModifiers.rangedAttack
 !mmm     set modifierLog = modifierLog & " {{" & activeMod.label & "=" & sign(activeMod.rollModifiers.rangedAttack, "display") & "}} "
-!mmm     set modifierTooltip = modifierTooltip & " " & activeMod.label & "&nbsp;&nbsp;&nbsp;" & activeMod.rollModifiers.rangedAttack & " "
+!mmm     set modifierTooltip = modifierTooltip & " " & activeMod.label & "&nbsp;&nbsp;&nbsp;" & sign(activeMod.rollModifiers.rangedAttack, "display") & " "
 !mmm   end for
 !rem   // 3. Target exhausted
 !mmm   if m3mgdIsExhausted(cTargetID)
@@ -535,7 +535,7 @@
 !rem   // If present, reduce counters for attack-specific modifier effects
 !mmm   set endOfActionSummary = m3mgdUpdatePersistentEffectsCounters(cOwnID, "attack")
 !mmm   if endOfActionSummary
-!mmm     set modifierLog = modifierLog & " {{ Zähler=" & endOfActionSummary & " }}"
+!mmm     set modifierLog = modifierLog & " {{ Angriffszähler=" & endOfActionSummary & " }}"
 !mmm   end if
 !mmm
 !mmm   if modifierLog ne "{{Boni/Mali=keine}}"

--- a/examples/midgard/tools/showPersistentEffects.mmm
+++ b/examples/midgard/tools/showPersistentEffects.mmm
@@ -1,4 +1,4 @@
-!rem // showPersistentEffects v0.1 2024-02-04 phr
+!rem // showPersistentEffects v0.2 2024-02-27 phr
 !rem //
 !rem // Chats a list of active persistent effects for the selected token, or all tokens if none are selected.
 !rem 
@@ -12,15 +12,21 @@
 !mmm   set payload = payload & literal("!mmm end customize") & "&#13;" & "&#x25;{MacroSheet|removePersistentEffect}" & "&#13;"
 !mmm   return payload
 !mmm end function
-!mmm   for effectRecord in (deserialize(m3mgdExchange.m3mgdActivePersistentEffects))...
+!mmm 
+!mmm set pEregistry = deserialize(m3mgdExchange.m3mgdActivePersistentEffects)
+!mmm set cleanRegistry = { pEregistry... where ...value ne undef }
+!mmm if not cleanRegistry
+!mmm   chat: ${"&"}{template:default} {\{name=No active persistent effects in current game}\}
+!mmm else
+!mmm   for effectRecord in cleanRegistry...
 !mmm     if (not selected or (selected and effectRecord.key eq selected)) and effectRecord.value
 !mmm       combine chat
 !mmm         chat: ${"&"}{template:default} {\{name=${effectRecord.key.token_name}: Active persistent effects}\}
 !mmm         set activeCounter = 0
 !mmm         for statusRule in m3mgdGetActivePersistentEffects(effectRecord.key)
 !mmm           set activeCounter = activeCounter + 1
-!mmm           chat: {{ #${activeCounter}, another ${statusRule.effect.expiry.count} ${statusRule.effect.expiry.type}s= ${highlight("📃", "info", statusRule.desc)}${statusRule.label}
-!mmm           for mod in statusRule.rollModifiers...
+!mmm           chat: {{ #${activeCounter}, another ${statusRule.effect.expiry.count} ${statusRule.effect.expiry.type}s= ${highlight("📃", "info", statusRule.desc)}${statusRule.label}: 
+!mmm           for mod in statusRule.effect.rollModifiers...
 !mmm             chat: ${sign(mod.value, "display")} ${mod.key}; 
 !mmm           end for
 !mmm           if statusRule.effect.noAttack
@@ -44,4 +50,6 @@
 !mmm       end combine
 !mmm     end if
 !mmm   end for
+!mmm end if
+!mmm
 !mmm end script


### PR DESCRIPTION
Issue #76, identified during our last game, had found that some critical combat effects have not just one but several persistent results. In the example we encountered, the failing character had to accept some limitation for the next round while his opponent was given a benefit, also to last one round. I had previously implemented only one of those effects and apparently ignored the other. The system is now a bit more versatile: it now handles as many persistent effects as necessary to be sparked by a single critical combat event.

In implementing and testing this improvement, I encountered and fixed several small bugs related to critical effects handling and the definition of the five critical effects tables.

All of this sounds bigger than these three commits are in terms of code changes; it's tested in the TEST game and *should* be all fine...