### PR TITLE
Persistent effects handling from critical combat effects: various bits of cleanup

### DIFF
--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -65,6 +65,7 @@
 !mmm   set m3mgdInjuryStatus = { m3mgdInjuryStatus, "status_broken_heart": { "noAttack": true, "noDefense": true, "label": "Schwere innere Verletzung", "icon": "", "desc": "Keine Angriffe oder Abwehr" } }
 !mmm   set m3mgdInjuryStatus = { m3mgdInjuryStatus, "status_white_tower": { "rollModifiers": { "meleeAttack": -4, "rangedAttack": -4, "defense": -4 }, "label": "Rippen schwer verletzt", "icon": "", "desc": "alles -4" } }
 !mmm
+!mmm   set m3mgdTokenAttributes = { "bar1": "Bewegung", "bar2": "AP", "bar3": "LP" }
 !mmm   set m3mgdPersistentEffectTranslations = { "meleeAttack": "Nahkampfangriff", "rangedAttack": "Fernkampfangriff", "defense": "Abwehr" }
 !mmm
 !mmm   set m3mgdSpellEffects = { "fireball": { name: "Feuerball", tokenSide: 1 }, "firewall": { name: "Feuerwand", tokenSide: 2 } }
@@ -92,7 +93,7 @@
 !mmm   publish to game: m3mgdValidAttackWeaponTypes, m3mgdValidMeleeAttackWeaponTypes, m3mgdValidRangedAttackWeaponTypes
 !mmm   publish to game: m3mgdArmorPiercingWeaponTypes
 !mmm   publish to game: m3mgdParryLargeShieldTypes, m3mgdParrySmallShieldTypes, m3mgdParrySmallShieldEffectiveAgainst, m3mgdParryStandardTypes, m3mgdParryStandardEffectiveAgainst
-!mmm   publish to game: m3mgdInjuryStatus, m3mgdPersistentEffectTranslations, m3mgdSpellEffects, m3mgdAttrXP, m3mgdAttrXPLog
+!mmm   publish to game: m3mgdInjuryStatus, m3mgdTokenAttributes, m3mgdPersistentEffectTranslations, m3mgdSpellEffects, m3mgdAttrXP, m3mgdAttrXPLog
 !mmm
 !rem   // Publish game-global functions defined below
 !rem
@@ -1792,16 +1793,6 @@
 !mmm     return false
 !mmm   end if
 !mmm   
-!rem   // For variable expiry counts where .count is not an integer, make the roll and update persistentEffect with the result
-!mmm   if persistentEffect.effect.expiry.count and (persistentEffect.effect.expiry.count + 0 ne persistentEffect.effect.expiry.count)
-!mmm     set persistentEffect = { persistentEffect, effect: { persistentEffect.effect, expiry: { persistentEffect.effect.expiry, count: roll(persistentEffect.effect.expiry.count) } } }
-!mmm   end if
-!mmm
-!rem   // New effects counting rounds need to be marked as new, so they are not immediately counted down at end of the current round
-!mmm   if persistentEffect.effect.expiry.type eq "round"
-!mmm     set persistentEffect = { persistentEffect, effect: { persistentEffect.effect, expiry: { persistentEffect.effect.expiry, new: true } } }
-!mmm   end if
-!mmm
 !mmm   do setattr(tokenID, "status_blue", tokenID.status_blue + 1)
 !mmm
 !mmm   set effectsDB = deserialize(m3mgdExchange.m3mgdActivePersistentEffects)
@@ -1868,16 +1859,30 @@
 !mmm     end for
 !mmm 
 !rem     // Wrap and store each applicable persistent effect
+!rem
 !mmm     if persistentEffectsList > 1
 !mmm       set pEcounter = 1
 !mmm     end if
+!mmm
 !mmm     for applicablePersistentEffect in persistentEffectsList
+!mmm
 !mmm       set completePersistentEffect = { effect: applicablePersistentEffect, label: criticalEffect.label, desc: descText }
+!mmm
 !mmm       if completePersistentEffect.effect.focus eq "foe"
 !mmm         set targetID = foeID
 !mmm       else if completePersistentEffect
 !mmm         set targetID = tokenID
 !mmm       end if
+!mmm
+!rem       // For variable expiry counts where .count is not an integer, make the roll and update persistentEffect with the result
+!mmm       if completePersistentEffect.effect.expiry.count and (completePersistentEffect.effect.expiry.count + 0 ne completePersistentEffect.effect.expiry.count)
+!mmm         set completePersistentEffect = { completePersistentEffect, effect: { completePersistentEffect.effect, expiry: { completePersistentEffect.effect.expiry, count: roll(completePersistentEffect.effect.expiry.count) } } }
+!mmm       end if
+!rem       // New effects counting rounds need to be marked as new, so they are not immediately counted down at end of the current round
+!mmm       if completePersistentEffect.effect.expiry.type eq "round"
+!mmm         set completePersistentEffect = { completePersistentEffect, effect: { completePersistentEffect.effect, expiry: { completePersistentEffect.effect.expiry, new: true } } }
+!mmm       end if
+!mmm
 !mmm       set completePersistentEffect = m3mgdStorePersistentEffect(targetID, completePersistentEffect)
 !mmm       if pEcounter
 !mmm         set pEcounterLabel = "(Effekt #" & pEcounter & ")"
@@ -1886,6 +1891,7 @@
 !mmm       if pEcounter
 !mmm         set pEcounter = pEcounter + 1
 !mmm       end if
+!mmm
 !mmm     end for
 !mmm
 !mmm   end combine
@@ -1999,7 +2005,7 @@
 !mmm     set effectsList = effectsList, m3mgdInjuryStatus.(persistentEffect.marker).label
 !mmm   end if
 !mmm   if persistentEffect.cappedAttribute
-!mmm     set effectsList = effectsList, " **" & persistentEffect.cappedAttribute & "** reduziert"
+!mmm     set effectsList = effectsList, m3mgdTokenAttributes.(persistentEffect.cappedAttribute) & " reduziert"
 !mmm   end if
 !mmm   return effectsList
 !mmm end function

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgard()
 !mmm   
-!mmm   set libVersion = "libMidgard v1.4.0-pre (2024-04-14)"
+!mmm   set libVersion = "libMidgard v1.4.0-pre (2024-05-24)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
@@ -15,7 +15,7 @@
 !mmm
 !rem   // Game-global constants for publication
 !rem
-!mmm   set m3mgdScriptCommands = { "defense": "&#x25;{MacroSheet|defense}", "melee": "&#x25;{MacroSheet|meleeAttack}", "ranged": "&#x25;{MacroSheet|rangedAttack}", "editXP": "&#x25;{MacroSheet|editXP}" }
+!mmm   set m3mgdScriptCommands = { "defense": "&#x25;{MacroSheet|defense}", "melee": "&#x25;{MacroSheet|meleeAttack}", "ranged": "&#x25;{MacroSheet|rangedAttack}", "editXP": "&#x25;{MacroSheet|editXP}", "removeEffect": "&#x25;{MacroSheet|removePersistentEffect}" }
 !mmm   set m3mgdExchangeDataSheet = "MacroSheet"
 !mmm   set m3mgdExchange = m3mgdExchangeDataSheet.character_id
 !mmm 
@@ -100,7 +100,7 @@
 !mmm   publish to game: m3mgdGetEnduranceAttribute, m3mgdGetHealthAttribute
 !mmm   publish to game: m3mgdValidateAttackData, _m3mgdExecuteCode, m3mgdRollChanceEffect, m3mgdFlushExchange
 !mmm   publish to game: _m3mgdHandleStoredAttr, m3mgdSetAttrCeiling, m3mgdAttrCeiling, m3mgdReleaseAttrCeiling
-!mmm   publish to game: m3mgdHasActivePersistentEffects, m3mgdGetActivePersistentEffects
+!mmm   publish to game: m3mgdHasActivePersistentEffects, m3mgdGetActivePersistentEffects, _m3mgdRemovePersistentEffectPayload
 !mmm   publish to game: m3mgdActiveStatusModifiers, m3mgdIsExhausted, m3mgdIsDefenseless, m3mgdIsUnfitToAttack
 !mmm   publish to game: m3mgdShapeMoji, m3mgdEnduranceStatusLabel, m3mgdEnduranceStatusEffectsDesc
 !mmm   publish to game: m3mgdHealthStatusLabel, m3mgdHealthStatusEffectsDesc
@@ -485,6 +485,20 @@
 !mmm   return deserialize(m3mgdExchange.m3mgdActivePersistentEffects).(tokenID)
 !mmm end function
 !rem
+!rem // _m3mgdRemovePersistentEffectPayload(tokenID, removeEffectIndex)
+!rem //
+!rem //   Returns a chat button payload to remove tokenID's active persistent effect identified by removeEffectIndex.
+!rem //
+!mmm function _m3mgdRemovePersistentEffectPayload(tokenID, removeEffectIndex)
+!mmm   set payload = literal("!mmm customize") & "&#13;"
+!mmm   set payload = payload & literal("!mmm set cmd=\"removeEffect\"") & "&#13;"
+!mmm   set payload = payload & literal("!mmm set tokenID=\"" & tokenID & "\"") & "&#13;"
+!mmm   set payload = payload & literal("!mmm set removeEffectIndex=\"" & removeEffectIndex & "\"") & "&#13;"
+!mmm   set payload = payload & literal("!mmm set deleteConfirm=?" & "{Für " & tokenID.token_name & " wirklich Effekt Nr." & (removeEffectIndex + 1) & " löschen?|Nein,false|Ja,true}") & "&#13;"
+!mmm   set payload = payload & literal("!mmm end customize") & "&#13;" & m3mgdScriptCommands.removeEffect & "&#13;"
+!mmm   return payload
+!mmm end function
+!rem
 !rem // m3mgdActiveStatusModifiers(tokenID, action)
 !rem //
 !rem //   Returns a list of tokenID's active status modifiers from severe injuries or critical effects for a given action (defense, meleeAttack, see, hear etc.).
@@ -564,7 +578,7 @@
 !mmm
 !mmm end function
 !rem
-!rem // m3mgdIsUnfitToAttack(tokenID)
+!rem // m3mgdIsUnfitToAttack(tokenID) 
 !rem // 
 !rem //   Returns true (and outputs the reasons to the chat) if tokenID is unable to attack. Otherwise returns false.
 !rem // 

--- a/examples/midgard/rangedAttack/rangedAttack.mmm
+++ b/examples/midgard/rangedAttack/rangedAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Ranged Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "2.0.0-pre (2024-03-16)"
+!mmm   set scriptVersion = "2.0.0-pre (2024-05-24)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -556,8 +556,7 @@
 !mmm   if effEnduranceLoss > 0
 !mmm     do m3mgdInjuryFX(cOwnID, 0, effEnduranceLoss / cOwnID.(m3mgdGetEnduranceAttribute(cOwnID)).max)
 !mmm   end if
-!mmm   debug do cAttackRoll
-!mmm   if attackResult >= 20 and not ? isfumble(cAttackRoll)
+!mmm   if attackResult >= 20 and not isfumble(cAttackRoll)
 !mmm     do m3mgdChatDefensePrompt(cTargetID, cOwnID, cWeaponType, "ranged")
 !mmm   end if
 !mmm

--- a/examples/midgard/tools/removePersistentEffect.mmm
+++ b/examples/midgard/tools/removePersistentEffect.mmm
@@ -1,4 +1,4 @@
-!rem // removePersistentEffect v0.1 2024-02-04 phr
+!rem // removePersistentEffect v1.0 2024-05-24 phr
 !rem //
 !rem // Removes an active persistent effect identified by tokenID and removeEffectIndex.
 !rem 
@@ -31,7 +31,7 @@
 !mmm     
 !mmm     do setattr(m3mgdExchange, "m3mgdActivePersistentEffects", serialize({ effectsDB, (tokenID): updatedActiveEffects }))
 !mmm
-!mmm     chat: Removed one active effect on ${highlight(tokenID.token_name, "info", tokenID)}.
+!mmm     chat: Dauereffekt #${removeEffectIndex+1} von ${highlight(tokenID.token_name, "info", tokenID)} beendet.
 !mmm   end if
 !mmm
 !mmm end script

--- a/examples/midgard/tools/showPersistentEffects.mmm
+++ b/examples/midgard/tools/showPersistentEffects.mmm
@@ -1,4 +1,4 @@
-!rem // showPersistentEffects v1.0 2024-04-24 phr 
+!rem // showPersistentEffects v1.1 2024-05-24 phr 
 !rem //
 !rem // Chats a list of active persistent effects for the selected token, or all tokens if none are selected.
 !rem 
@@ -18,11 +18,17 @@
 !mmm set pEregistry = deserialize(m3mgdExchange.m3mgdActivePersistentEffects)
 !mmm set cleanRegistry = { pEregistry... where ...value ne undef }
 !mmm if not cleanRegistry
-!mmm   do chat(chatTightBoxRow("No active persistent effects in current game"))
+!mmm   do chat(chatTightBoxRow("Keine persistenten Effekte im aktuellen Spiel."))
 !mmm   exit script
 !mmm end if
 !mmm 
-!mmm set output = chatTightBoxHeader("Active persistent effects")
+!mmm if selected
+!mmm   set refLabel = selected.token_name
+!mmm else
+!mmm   set refLabel = "alle"
+!mmm end if
+!mmm set output = chatTightBoxHeader("Persistente Effekte für " & refLabel)
+!mmm
 !mmm for affectedTokenRecord in cleanRegistry...
 !rem   // If there is a selected token, only produce output for this token alone. If there is no selected token, produce output for every token with an active persistent effect.
 !mmm   if (not selected or (selected and affectedTokenRecord.key eq selected)) and affectedTokenRecord.value
@@ -39,5 +45,10 @@
 !mmm       end for
 !mmm   end if
 !mmm end for
+!mmm
+!mmm if activeCounter == 0
+!mmm   set output = output & chatTightBoxRow("keine")
+!mmm end if
+!mmm
 !mmm do chat(output)
 !mmm end script

--- a/examples/midgard/tools/showPersistentEffects.mmm
+++ b/examples/midgard/tools/showPersistentEffects.mmm
@@ -3,22 +3,13 @@
 !rem // Chats a list of active persistent effects for the selected token, or all tokens if none are selected.
 !rem 
 !mmm script
-!mmm function removeEffectPayload(tokenID, removeEffectIndex)
-!mmm   set payload = literal("!mmm customize") & "&#13;"
-!mmm   set payload = payload & literal("!mmm set cmd=\"removeEffect\"") & "&#13;"
-!mmm   set payload = payload & literal("!mmm set tokenID=\"" & tokenID & "\"") & "&#13;"
-!mmm   set payload = payload & literal("!mmm set removeEffectIndex=\"" & removeEffectIndex & "\"") & "&#13;"
-!mmm   set payload = payload & literal("!mmm set deleteConfirm=?" & "{Für " & tokenID.token_name & " wirklich Effekt Nr." & (removeEffectIndex + 1) & " löschen?|Nein,false|Ja,true}") & "&#13;"
-!mmm   set payload = payload & literal("!mmm end customize") & "&#13;" & "&#x25;{MacroSheet|removePersistentEffect}" & "&#13;"
-!mmm   return payload
-!mmm end function
 !mmm 
 !rem // MAIN
 !rem
 !mmm set pEregistry = deserialize(m3mgdExchange.m3mgdActivePersistentEffects)
 !mmm set cleanRegistry = { pEregistry... where ...value ne undef }
 !mmm if not cleanRegistry
-!mmm   do chat(chatTightBoxRow("Keine persistenten Effekte im aktuellen Spiel."))
+!mmm   do chat(chatTightBoxRow("Keine Dauereffekte im aktuellen Spiel."))
 !mmm   exit script
 !mmm end if
 !mmm 
@@ -27,7 +18,7 @@
 !mmm else
 !mmm   set refLabel = "alle"
 !mmm end if
-!mmm set output = chatTightBoxHeader("Persistente Effekte für " & refLabel)
+!mmm set output = chatTightBoxHeader("Dauereffekte für " & refLabel)
 !mmm
 !mmm for affectedTokenRecord in cleanRegistry...
 !rem   // If there is a selected token, only produce output for this token alone. If there is no selected token, produce output for every token with an active persistent effect.
@@ -41,7 +32,7 @@
 !mmm         if statusRule.effect
 !mmm           set line = line & " - " & stringify(m3mgdPersistentEffectLabels(statusRule.effect), "", "; ")
 !mmm         end if
-!mmm         set output = output & chatTightBoxButtonRow(line, tooltip, removeEffectPayload(affectedTokenRecord.key, activeCounter-1))
+!mmm         set output = output & chatTightBoxButtonRow(line, tooltip, _m3mgdRemovePersistentEffectPayload(affectedTokenRecord.key, activeCounter-1))
 !mmm       end for
 !mmm   end if
 !mmm end for

--- a/examples/midgard/weaponSelect/weaponSelect.mmm
+++ b/examples/midgard/weaponSelect/weaponSelect.mmm
@@ -1,6 +1,7 @@
 !rem // Midgard combat weapon selector script
+!rem //
 !mmm script
-!mmm   set scriptVersion = "weaponSelect v1.1.1 (2022-03-12)"
+!mmm   set scriptVersion = "weaponSelect v1.2 (2024-05-24)"
 !rem
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -24,12 +25,15 @@
 !mmm     exit script
 !mmm   end if
 !mmm
+!rem   // Inform user, abort attack if injury or critical effect status does not allow for it, and count down persistent effects if required
+!mmm   if m3mgdIsUnfitToAttack(cOwnID)
+!mmm     exit script
+!mmm   end if
+!rem
 !rem   // MAIN: Generate weapon selector menus for each weapon group requested 
 !mmm
 !mmm   for weaponGroup in cWeaponGroups
-!mmm     
 !mmm     do chat(cOwnID.token_name, "/w \"" & cOwnID.character_name & "\" " & m3mgdWeaponSelectorChatMenu(cOwnID, weaponGroup))
-!mmm       
 !mmm   end for
 !mmm
 !mmm end script


### PR DESCRIPTION
Most importantly, the weaponSelector script at the start of each combat action now checks for "fitness for attack", so if there is any effect preventing an attack the player does no longer need to input all the details of the planned maneuver before learning that their character is currently too confused or something. Along with this, some cleanup and moving around of small bits of logic and output cleanup in preparation for more output cleanup and further tweaks to help players handle persistent effects more smoothly during combat.