### PR TITLE
`magicAttack`, `defense`, `libMidgard`: small improvements

### DIFF
--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "defense 2.1.0 (2024-11-17)"
+!mmm   set scriptVersion = "defense 2.1.1 (2025-03-12)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -84,6 +84,7 @@
 !mmm   set modifierLog = ""
 !mmm   set modifierTooltip = ""
 !mmm
+!mmm   set attackerID = m3mgdExchange.(m3mgdAttrAttackerID)
 !mmm   set attackType = m3mgdExchange.(m3mgdAttrAttackType)
 !mmm   set attackResult = m3mgdExchange.(m3mgdAttrAttackResult)
 !mmm   set criticalAttack = (m3mgdExchange.(m3mgdAttrAttackResult).max eq "true")
@@ -99,6 +100,7 @@
 !rem   // Special case: magic spells whose name is stored in attack_type.max
 !mmm   if m3mgdExchange.(m3mgdAttrAttackType).max ne ""
 !mmm     set attackSpell = m3mgdExchange.(m3mgdAttrAttackType).max
+!mmm     set attackEnduranceCost = m3mgdExchange.(m3mgdAttrAttackEnduranceCost)
 !mmm     set attackSpellType = attackWeaponType
 !mmm     if attackSpellType eq "Geist"
 !mmm       set defenseProperty = "ResGeist"
@@ -106,7 +108,7 @@
 !mmm     else if attackSpellType eq "Körper"
 !mmm       set defenseProperty = "ResKörper"
 !mmm       set defensePropertyBonus = "BonusResK"
-!mmm     else if attackSpellType eq "Bewegung"
+!mmm     else if attackSpellType eq "Umgebung"
 !mmm       set defenseProperty = "Abwehr"
 !mmm       set defensePropertyBonus = "BonusAbwehr"
 !mmm     else 
@@ -254,6 +256,13 @@
 !rem     // Defense failed (or there was no defense)
 !mmm     set defenseSuccess = false
 !mmm
+!rem     // Critically successful magic attacks
+!mmm     if attackSpell and criticalAttack and defenseResult < 20
+!mmm       set attackDamage = attackDamage * 2
+!mmm     else if attackSpell and criticalAttack and not isfumble(cDefenseRoll) and attackEnduranceCost >= 2
+!mmm       set attackerNewEndurance = m3mgdModifyEndurance(floor(attackEnduranceCost / 2), attackerID)
+!mmm     end if
+!mmm
 !rem     // Defender loses full hit points worth of endurance regardless of armor, if not an undead creature with unlimited endurance
 !mmm     if not cOwnID.(cEnduranceAttr).max == 0
 !mmm       set effEnduranceLoss = attackDamage
@@ -287,15 +296,15 @@
 !mmm   end if
 !rem
 !rem   // Process experience gain for attacker if script is run on an NPC, in which case player is GM with control over attacker sheet
-!mmm   if isChar(m3mgdExchange.(m3mgdAttrAttackerID)) and not cNoDefense and ((cOwnID.(cEnduranceAttr).max == 0 and not defenseSuccess) or (cOwnID.(cEnduranceAttr).max != 0 and endurance > 0 and effEnduranceLoss > 0))
-!mmm     set xpGain = m3mgdProcessAttackXP(m3mgdExchange.(m3mgdAttrAttackType), attackDamageRoll, m3mgdExchange.(m3mgdAttrAttackerID), cOwnID)
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & m3mgdExchange.(m3mgdAttrAttackerID).name & ": +" & xpGain & " EP}} "
+!mmm   if isChar(attackerID) and not cNoDefense and ((cOwnID.(cEnduranceAttr).max == 0 and not defenseSuccess) or (cOwnID.(cEnduranceAttr).max != 0 and endurance > 0 and effEnduranceLoss > 0))
+!mmm     set xpGain = m3mgdProcessAttackXP(m3mgdExchange.(m3mgdAttrAttackType), attackDamageRoll, attackerID, cOwnID)
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackerID.name & ": +" & xpGain & " EP}} "
 !mmm   else if not cNoDefense and cOwnID.(cEnduranceAttr).max == 0 and defenseSuccess
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & m3mgdExchange.(m3mgdAttrAttackerID).name & ": keine (∞ AP, abgewehrt) }} "
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackerID.name & ": keine (∞ AP, abgewehrt) }} "
 !mmm   else if cNoDefense or (cOwnID.(cEnduranceAttr).max != 0 and endurance <= 0)
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & m3mgdExchange.(m3mgdAttrAttackerID).name & ": keine (Ziel erschöpft/wehrlos) }} "
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackerID.name & ": keine (Ziel erschöpft/wehrlos) }} "
 !mmm   else if cOwnID.(cEnduranceAttr).max != 0 and effEnduranceLoss <= 0
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & m3mgdExchange.(m3mgdAttrAttackerID).name & ": keine (kein AP-Verlust) }} "
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackerID.name & ": keine (kein AP-Verlust) }} "
 !mmm   end if
 !mmm
 !rem   // Register practice point, if applicable
@@ -360,7 +369,7 @@
 !mmm   
 !rem   // Weapon-specific special damage effects
 !mmm   if not defenseSuccess and attackWeaponSpecialEffect
-!mmm     do m3mgdWeaponSpecialEffect(attackWeaponSpecialEffect, m3mgdExchange.(m3mgdAttrAttackerID))
+!mmm     do m3mgdWeaponSpecialEffect(attackWeaponSpecialEffect, attackerID)
 !mmm   end if
 !mmm
 !rem   // Injury & exhaustion special effects

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgard()
 !mmm   
-!mmm   set libVersion = "libMidgard v1.5.0-pre (2024-11-17)"
+!mmm   set libVersion = "libMidgard v1.5.0-pre (2025-03-12)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
@@ -32,6 +32,7 @@
 !mmm   set m3mgdAttrAttackDamage        = "m3mgd_attack_damage"
 !mmm   set m3mgdAttrAttackDamageRoll    = "m3mgd_attack_damage_roll"
 !mmm   set m3mgdAttrAttackWeaponType    = "m3mgd_attack_weapon_type"
+!mmm   set m3mgdAttrAttackEnduranceCost = "m3mgd_attack_endurance_cost"
 !mmm   set m3mgdAttrHealthGain          = "m3mgd_health_gain"
 !mmm   set m3mgdAttrEnduranceGain       = "m3mgd_endurance_gain"
 !mmm
@@ -87,7 +88,7 @@
 !mmm   set m3mgdAttrXPLog = "Erfahrungsprotokoll"
 !mmm
 !mmm   publish to game: m3mgdScriptCommands, m3mgdExchange
-!mmm   publish to game: m3mgdAttrAttackType, m3mgdAttrAttackerID, m3mgdAttrAttackTargetID, m3mgdAttrAttackResult, m3mgdAttrAttackDamage, m3mgdAttrAttackDamageRoll, m3mgdAttrAttackWeaponType
+!mmm   publish to game: m3mgdAttrAttackType, m3mgdAttrAttackerID, m3mgdAttrAttackTargetID, m3mgdAttrAttackResult, m3mgdAttrAttackDamage, m3mgdAttrAttackDamageRoll, m3mgdAttrAttackWeaponType, m3mgdAttrAttackEnduranceCost
 !mmm   publish to game: m3mgdAttrHealthGain, m3mgdAttrEnduranceGain
 !mmm   publish to game: m3mgdExchangeAttrList
 !mmm   publish to game: m3mgdValidAttackWeaponTypes, m3mgdValidMeleeAttackWeaponTypes, m3mgdValidRangedAttackWeaponTypes
@@ -1273,6 +1274,13 @@
 !mmm     end if
 !mmm   end if
 !mmm
+!mmm   if script.magicEnduranceCost ne undef
+!mmm     set storeTarget = storeTarget + 1
+!mmm     if setattr(dataExchangeID, m3mgdAttrAttackEnduranceCost, script.magicEnduranceCost) == script.magicEnduranceCost
+!mmm       set storeCounter = storeCounter + 1
+!mmm     end if
+!mmm   end if
+!mmm
 !mmm   return (storeCounter == storeTarget)
 !mmm   
 !mmm end function
@@ -1858,6 +1866,7 @@
 !mmm   else if combatMode eq "defense" and attackSpellType eq "Umgebung"
 !mmm   
 !mmm     do setattr(m3mgdExchange, m3mgdAttrAttackDamage, spellDamage)
+!mmm     do setattr(m3mgdExchange, m3mgdAttrAttackDamageRoll, spellDamage)
 !mmm     return m3mgdWeaponSelectorChatMenu(tokenID, "defense", "magic")
 !mmm   
 !mmm   else if combatMode eq "defense" and (attackSpellType eq "Geist" or attackSpellType eq "Körper")
@@ -1865,7 +1874,7 @@
 !mmm     if isdefault(spellDamage)
 !mmm       do whisperback("Schadenseingabe fehlt.")
 !mmm     else
-!mmm       if setattr(m3mgdExchange, m3mgdAttrAttackDamage, spellDamage) != spellDamage
+!mmm       if setattr(m3mgdExchange, m3mgdAttrAttackDamage, spellDamage) + setattr(m3mgdExchange, m3mgdAttrAttackDamageRoll, spellDamage) != spellDamage / 2
 !mmm         do whisperback("Schaden konnte nicht gespeichert werden.")
 !mmm       end if
 !mmm     end if
@@ -2708,7 +2717,12 @@
 !mmm       chat: [🎲](${m3mgdCriticalEffectRollPayload(m3mgdExchange.(m3mgdAttrAttackerID), "attackSuccess", script.cOwnID)}${cssTableCellButton})
 !mmm       chat: [🎲](${m3mgdCriticalEffectRollPayload(script.cOwnID, "defenseFailure", m3mgdExchange.(m3mgdAttrAttackerID))}${cssTableCellButton}) }\}
 !mmm     else if script.criticalAttack == true
-!mmm       chat: {\{Fehlschlag=${script.defenseResult} **Schwerer kritischer Treffer** [🎲](${m3mgdCriticalEffectRollPayload(m3mgdExchange.(m3mgdAttrAttackerID), "attackSuccess", script.cOwnID)}${cssTableCellButton}) }\}
+!mmm       chat: {\{Fehlschlag=${script.defenseResult} **Schwerer kritischer Treffer** 
+!mmm       if m3mgdExchange.(m3mgdAttrAttackType) ne "magic"
+!mmm         chat: [🎲](${m3mgdCriticalEffectRollPayload(m3mgdExchange.(m3mgdAttrAttackerID), "attackSuccess", script.cOwnID)}${cssTableCellButton}) }\}
+!mmm       else
+!mmm         chat: }\}
+!mmm       end if
 !mmm     else if isfumble(script.cDefenseRoll)
 !mmm       chat: {\{Kritischer Fehlschlag=${script.defenseResult} **Schwerer kritischer Treffer** [🎲](${m3mgdCriticalEffectRollPayload(script.cOwnID, "defenseFailure", m3mgdExchange.(m3mgdAttrAttackerID))}${cssTableCellButton}) }\}
 !mmm     else 
@@ -2724,7 +2738,12 @@
 !mmm     end if
 !mmm
 !mmm     if script.criticalAttack == true and m3mgdExchange.(m3mgdAttrAttackType) eq "magic"
-!mmm       chat: {\{Kritischer Zaubererfolg=Zauber wirkt **doppelt so stark** oder ist **halb so teuer**: Nach Wahl des Zauberers umsetzen.}\}
+!mmm       chat: {\{Kritischer Zaubererfolg=
+!mmm       if script.defenseResult < 20
+!mmm         chat: Zauber wirkt **doppelt so stark** (Abwehrergebnis < 20, Schaden wurde verdoppelt)}\}
+!mmm       else 
+!mmm         chat: Zauber ist **halb so teuer** (Zauberer wurden ${floor(script.attackEnduranceCost/2)} AP gutgeschrieben).}\}
+!mmm       end if
 !mmm     end if
 !mmm
 !mmm     if script.newHealth < 0 and script.timeToDie < 0
@@ -2781,7 +2800,7 @@
 !mmm       set attackSpellType = attackerID.(findattr(attackerID, "Zauber", "Zauber", weaponType, "Ziel"))
 !mmm       set approvePayload = approvePayload & literal("!mmm set attackDamage='?" & "{Schadenspunkte, falls Resistenz/Abwehr misslingt|}'") & "&#13;"
 !mmm       set approvePayload = approvePayload & literal("!mmm do chat('" & attackerID.token_name & "', '/w \"" & targetID.character_name & "\" ' & m3mgdSpellSelectorChatMenu(\"" & targetID & "\", \"defense\", \"" & attackSpellType & "\", attackDamage))") & "&#13;"
-!mmm       set rerollPayload = _m3mgdSpellButtonPayload(attackerID, weaponsType, default, { cTargetID: targetID, cManualModifiers: script.cManualModifiers })
+!mmm       set rerollPayload = _m3mgdSpellButtonPayload(attackerID, weaponType, default, { cTargetID: targetID, cManualModifiers: script.cManualModifiers })
 !mmm     else 
 !mmm       set approvePayload = approvePayload & literal("!mmm do chat('" & attackerID.token_name & "', '/w \"" & targetID.character_name & "\" ' & m3mgdWeaponSelectorChatMenu(\"" & targetID & "\", \"defense\", \"" & weaponType & "\"))") & "&#13;"
 !mmm       set rerollPayload = _m3mgdWeaponButtonPayload(attackerID, weaponsGroup, script.cWeaponLabel, default, { cTargetID: targetID, cSemiManualModifiers: script.cSemiManualModifiers, cManualModifiers: script.cManualModifiers })

--- a/examples/midgard/magicAttack/magicAttack.mmm
+++ b/examples/midgard/magicAttack/magicAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Magic Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "1.0.0pre (2024-11-17)"
+!mmm   set scriptVersion = "1.0.1pre (2025-03-12)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -203,7 +203,8 @@
 !mmm     if attackResult >= 20 and not isfumble(cAttackRoll)
 !mmm       chat:    {{Zauberdauer=${cOwnID.(findattr(cOwnID, "Zauber", "Zauber", cAttackSpell, "ZD"))} (Art: ${cOwnID.(findattr(cOwnID, "Zauber", "Zauber", cAttackSpell, "Art"))}/${cOwnID.(findattr(cOwnID, "Zauber", "Zauber", cAttackSpell, "Prozess"))})}}
 !mmm       chat:    {{Zauberziel=${cOwnID.(findattr(cOwnID, "Zauber", "Zauber", cAttackSpell, "Ziel"))} / ${cOwnID.(findattr(cOwnID, "Zauber", "Zauber", cAttackSpell, "WB"))} / max. ${cOwnID.(findattr(cOwnID, "Zauber", "Zauber", cAttackSpell, "RW"))} Entfernung}}
-!mmm       chat:    {{Wirkungsdauer=${cOwnID.(findattr(cOwnID, "Zauber", "Zauber", cAttackSpell, "WD"))}}}
+!mmm       chat:    {{Wirkungsdauer=${cOwnID.(findattr(cOwnID, "Zauber", "Zauber", cAttackSpell, "WD"))} }}
+!rem  //     chat:    {{Material/Kosten=...}}
 !mmm     end if
 !mmm   end combine
 !mmm


### PR DESCRIPTION
- changed handling of critical successes in magic attacks
- AP costs of magic attacks are now passed to `defense.mmm` for modification (reduction by half in case of critical successes)
- very old typo bug in `libMidgard` fixed (`weaponType` vs. `weaponsType`)