### PR TITLE
Expose per-token nameplate settings as pseudo-attributes

### DIFF
--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -1,7 +1,7 @@
 // Mych's Macro Magic by Michael Buschbeck <michael@buschbeck.net> (2021)
 // https://github.com/michael-buschbeck/mychs-macro-magic/blob/main/LICENSE
 
-const MMM_VERSION = "1.36.2";
+const MMM_VERSION = "1.37.0";
 
 const MMM_STARTUP_INSTANCE = MMM_VERSION + "/" + new Date().toISOString();
 const MMM_STARTUP_SENDER = "MMM-f560287b-c9a0-4273-bf03-f2c1f97d24d4";
@@ -1883,6 +1883,12 @@ class MychScriptContext extends MychStash
     {
         switch (attributeName)
         {
+            case "token_name_plate":
+            case "token_name_shown":
+            {
+                return this.privileged;
+            }
+
             case "bar1_edit":
             case "bar2_edit":
             case "bar3_edit":
@@ -2166,6 +2172,8 @@ class MychScriptContext extends MychStash
             "name",
             "character_name",
             "token_name",
+            "token_name_plate",
+            "token_name_shown",
             "character_id",
             "token_id",
             "page",
@@ -2277,6 +2285,20 @@ class MychScriptContext extends MychStash
             {
                 lookupObj = token;
                 lookupKey = (max ? undefined : "name");
+            }
+            break;
+
+            case "token_name_plate":
+            {
+                lookupObj = token;
+                lookupKey = (max ? undefined : "showname");
+            }
+            break;
+
+            case "token_name_shown":
+            {
+                lookupObj = token;
+                lookupKey = (max ? undefined : "showplayers_name");
             }
             break;
 
@@ -2513,6 +2535,22 @@ class MychScriptContext extends MychStash
             case "token_name":
             {
                 updateObj = token;
+            }
+            break;
+
+            case "token_name_plate":
+            {
+                updateObj = token;
+                updateKey = (max ? undefined : "showname");
+                updateVal = MychExpression.coerceBoolean(attributeValue);
+            }
+            break;
+
+            case "token_name_shown":
+            {
+                updateObj = token;
+                updateKey = (max ? undefined : "showplayers_name");
+                updateVal = MychExpression.coerceBoolean(attributeValue);
             }
             break;
 

--- a/README.md
+++ b/README.md
@@ -882,6 +882,8 @@ MMM has a more general notion of what attributes are than Roll20 itself and adds
 | `name`               | `"Finn"`             | read   |       | Character or token name
 | `token_id`           |                      | read   |       | Token ID
 | `token_name`         | `"Finn's Spiderbro"` | read   |       | Token name – provided for Roll20 parity
+| `token_name_plate`   | `true`               | write  |       | Whether the token has a name plate
+| `token_name_shown`   | `true`               | write  |       | Whether the token's name plate is shown to other players
 | `character_id`       |                      | read   |       | Character ID
 | `character_name`     | `"Finn"`             | read   |       | Character name – provided for Roll20 parity
 | `page`               | `"-MRZtlN_1XJe4k"`   | read   |       | Page ID on which the token is displayed
@@ -1248,6 +1250,7 @@ If nothing is sent to chat at all after entering this command, MMM isn't install
 
 | Version | Date       | What's new?
 | ------- | ---------- | -----------
+| 1.37.0  | 2024-10-11 | Support `token_name_plate` and `token_name_shown` token attributes
 | 1.36.0  | 2023-06-13 | Support `selected` override
 | 1.35.0  | 2022-05-10 | Support `bars_style_top`, `bars_style_overlap`, and `bars_style_compact` token attributes
 | 1.34.0  | 2022-05-06 | Add markup-preserving `&&` string concatenation operator


### PR DESCRIPTION
Expose per-token nameplate settings as pseudo-attributes `token_name_plate` (bool) and `token_name_shown` (bool).

Version: 1.37.0
Resolves: #226
