### PR TITLE
Rebuilt internal data exchange between scripts to be more versatile

### DIFF
--- a/examples/midgard/defense/defendFrostball.mmm
+++ b/examples/midgard/defense/defendFrostball.mmm
@@ -1,7 +1,7 @@
 !rem // Defends against Midgard's Frostball spell, as defined in Arkanum:86
 !rem //
 !mmm script
-!mmm   set scriptVersion = "defendFrostball 1.5.1 (2024-02-03)"
+!mmm   set scriptVersion = "defendFrostball 1.6.0-WIP2 (2025-04-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -24,30 +24,43 @@
 !mmm   end if
 !mmm   set customizable cHealthAttr = "bar3"
 !mmm   set customizable cEnduranceAttr = "bar2"
+!mmm   set customizable searchByOrigin = default
+!mmm   set customizable searchByAttackResult = default
+!mmm   set customizable searchByDamageResult = default
 !mmm
 !mmm   set endurance = cOwnID.(cEnduranceAttr)
 !mmm   set health = cOwnID.(cHealthAttr)
 !mmm   set maxEndurance = cOwnID.(cEnduranceAttr).max
 !mmm   set maxHealth = cOwnID.(cHealthAttr).max
 !mmm
-!mmm   set attackType = m3mgdExchange.(m3mgdAttrAttackType)
-!mmm   if not (attackType eq "magic" and m3mgdExchange.(m3mgdAttrAttackType).max eq "Frostball")
-!mmm     do whisperback("Wrong attack/spell data found: '" & m3mgdExchange.(m3mgdAttrAttackType) & "' / '" & m3mgdExchange.(m3mgdAttrAttackType).max & "'")
-!mmm     exit script
+!mmm   set attackData = m3mgdRetrieveAttack(cOwnID)
+!mmm   if not (attackData and attackData.attackType eq "magic" and attackData.magicSpell eq "Frostball")
+!mmm     set filter = { action: "combatAttack", attackType: "magic", magicSpell: "Frostball" }
+!mmm     if not isdefault(searchByOrigin)
+!mmm       set filter = { filter, origin: searchByOrigin }
+!mmm     end if
+!mmm     if not isdefault(searchByAttackResult)
+!mmm       set filter = { filter, attackResult: searchByAttackResult }
+!mmm     end if
+!mmm     if not isdefault(searchByDamageResult)
+!mmm       set filter = { filter, damageResult: searchByDamageResult }
+!mmm     end if
+!mmm     set attackData = m3mgdExchangeGetData(m3mgdExchangeRegistries.combatData, filter)
+!mmm     if not attackData or count(attackData) > 1
+!mmm       do whisperback("Wrong attack/spell data found.")
+!mmm       do whisperback(m3mgdExchangeAssignAttack(m3mgdExchangeRegistries.combatData, { action: "combatAttack", attackType: "magic", magicSpell: "Frostball" }, cOwnID))
+!mmm       exit script
+!mmm     end if
+!mmm     debug chat: Identified a single dataset that fits: ${attackData}
 !mmm   end if
 !mmm   
-!mmm   set attackResult = m3mgdExchange.(m3mgdAttrAttackResult)
-!mmm   if isdenied(attackResult) or isunknown(attackResult)
-!mmm     do whisperback("Access to attack result value failed: " & getreason(attackResult))
-!mmm     exit script
-!mmm   end if
-!mmm   set criticalAttack = (m3mgdExchange.(m3mgdAttrAttackResult).max eq "true")
-!mmm   if criticalAttack == true
+!mmm   set attackResult = attackData.attackResult
+!mmm   if attackData.criticalAttack == true
 !mmm     set attackResult = highlight(attackResult, "good")
 !mmm   else 
 !mmm     set attackResult = highlight(attackResult, "normal")
 !mmm   end if 
-!mmm   set enduranceDamage = m3mgdExchange.(m3mgdAttrAttackDamage)
+!mmm   set enduranceDamage = attackData.damageResult
 !mmm
 !mmm   set defenseModifier = 0
 !mmm   if endurance <= 0
@@ -55,14 +68,14 @@
 !mmm   end if
 !mmm
 !rem   // Dazzle players with special effect
-!mmm   do spawnfx("beam-frost", m3mgdExchange.(m3mgdAttrAttackerID).left, m3mgdExchange.(m3mgdAttrAttackerID).top, cOwnID.left, cOwnID.top)
+!mmm   do spawnfx("beam-frost", attackData.origin.left, attackData.origin.top, cOwnID.left, cOwnID.top)
 !mmm
 !mmm   set defenseResult = roll("1d20+" & (cOwnID.Abwehr + defenseModifier))
 !mmm   
 !mmm   set effEnduranceLoss = 0
 !mmm   set effHealthLoss = 0
 !mmm
-!mmm   if iscritical(defenseResult) or (criticalAttack == false and defenseResult >= attackResult)
+!mmm   if iscritical(defenseResult) or (attackData.criticalAttack == false and defenseResult >= attackResult)
 !mmm     
 !rem     // Defense successful
 !mmm     set defenseSuccess = true
@@ -101,15 +114,15 @@
 !mmm   set effHealthLoss = highlight(effHealthLoss, "info")
 !mmm
 !rem   // Process experience gain for attacker if script is run on an NPC, in which case player is GM with control over attacker sheet
-!mmm   if isChar(m3mgdExchange.(m3mgdAttrAttackerID)) and not cNoDefense and ((cOwnID.(cEnduranceAttr).max == 0 and not defenseSuccess) or (cOwnID.(cEnduranceAttr).max != 0 and endurance > 0 and effEnduranceLoss > 0))
-!mmm     set xpGain = m3mgdProcessAttackXP(m3mgdExchange.(m3mgdAttrAttackType), effEnduranceLoss, m3mgdExchange.(m3mgdAttrAttackerID), cOwnID)
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & m3mgdExchange.(m3mgdAttrAttackerID).name & ": +" & xpGain & " EP}} "
+!mmm   if isChar(attackData.origin) and not cNoDefense and ((cOwnID.(cEnduranceAttr).max == 0 and not defenseSuccess) or (cOwnID.(cEnduranceAttr).max != 0 and endurance > 0 and effEnduranceLoss > 0))
+!mmm     set xpGain = m3mgdProcessAttackXP(attackData.attackType, effEnduranceLoss, attackData.origin, cOwnID)
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": +" & xpGain & " EP}} "
 !mmm   else if not cNoDefense and cOwnID.(cEnduranceAttr).max == 0 and defenseSuccess
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & m3mgdExchange.(m3mgdAttrAttackerID).name & ": keine (∞ AP, abgewehrt) }} "
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": keine (∞ AP, abgewehrt) }} "
 !mmm   else if cNoDefense or (cOwnID.(cEnduranceAttr).max != 0 and endurance <= 0)
-!mmm       set modifierLog = modifierLog & " {{ Erfahrung=" & m3mgdExchange.(m3mgdAttrAttackerID).name & ": keine (Ziel erschöpft/wehrlos) }} "
+!mmm       set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": keine (Ziel erschöpft/wehrlos) }} "
 !mmm   else if cOwnID.(cEnduranceAttr).max != 0 and effEnduranceLoss <= 0
-!mmm       set modifierLog = modifierLog & " {{ Erfahrung=" & m3mgdExchange.(m3mgdAttrAttackerID).name & ": keine (kein AP-Verlust) }} "
+!mmm       set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": keine (kein AP-Verlust) }} "
 !mmm   end if
 !mmm
 !mmm   if cOwnID.token_name ne sender
@@ -141,7 +154,7 @@
 !mmm   end if
 !rem
 !rem   // Output data table using data table execution code from library
-!mmm   do m3mgdDefenseDataTable()
+!mmm   do m3mgdDefenseDataTable(attackData)
 !mmm   
 !rem   // Output modifier log and PP reminder
 !mmm   chat: /w GM ${"&"}{template:default} ${modifierLog}

--- a/examples/midgard/defense/defendFrostball.mmm
+++ b/examples/midgard/defense/defendFrostball.mmm
@@ -1,7 +1,7 @@
 !rem // Defends against Midgard's Frostball spell, as defined in Arkanum:86
 !rem //
 !mmm script
-!mmm   set scriptVersion = "defendFrostball 1.6.0-WIP2 (2025-04-16)"
+!mmm   set scriptVersion = "defendFrostball 1.6.0 (2025-04-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion

--- a/examples/midgard/defense/defendSnatch.mmm
+++ b/examples/midgard/defense/defendSnatch.mmm
@@ -5,7 +5,7 @@
 !mmm   set cTargetID = "@{target|Angriffsziel|token_id}"
 !mmm end customize
 !mmm script
-!mmm   set scriptVersion = "defendSnatch 1.2.2 (2022-01-29)"
+!mmm   set scriptVersion = "defendSnatch 1.3.0 (2025-04-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -26,19 +26,30 @@
 !mmm     set customizable cTargetID = sender.token_id
 !mmm   end if
 !mmm
-!mmm   if not (m3mgdExchange.(m3mgdAttrAttackType) eq "magic" and m3mgdExchange.(m3mgdAttrAttackType).max eq "Snatch")
-!mmm     do whisperback("Wrong attack/spell data found: '" & m3mgdExchange.(m3mgdAttrAttackType) & "' / '" & m3mgdExchange.(m3mgdAttrAttackType).max & "'")
-!mmm     exit script
+!mmm   set customizable searchByOrigin = default
+!mmm   set customizable searchByAttackResult = default
+!mmm
+!mmm   set attackData = m3mgdRetrieveAttack(cTargetID)
+!mmm   if not (attackData and attackData.attackType eq "magic" and attackData.magicSpell eq "Snatch")
+!mmm     set filter = { action: "combatAttack", attackType: "magic", magicSpell: "Snatch" }
+!mmm     if not isdefault(searchByOrigin)
+!mmm       set filter = { filter, origin: searchByOrigin }
+!mmm     end if
+!mmm     if not isdefault(searchByAttackResult)
+!mmm       set filter = { filter, attackResult: searchByAttackResult }
+!mmm     end if
+!mmm     set attackData = m3mgdExchangeGetData(m3mgdExchangeRegistries.combatData, filter)
+!mmm     if not attackData or count(attackData) > 1
+!mmm       do whisperback("Wrong attack/spell data found.")
+!mmm       do whisperback(m3mgdExchangeAssignAttack(m3mgdExchangeRegistries.combatData, { action: "combatAttack", attackType: "magic", magicSpell: "Snatch" }, cOwnID))
+!mmm       exit script
+!mmm     end if
+!mmm     debug chat: Identified a single dataset that fits: ${attackData}
 !mmm   end if
 !mmm   
-!mmm   set attackerID = m3mgdExchange.(m3mgdAttrAttackerID)
-!mmm   set attackResult = m3mgdExchange.(m3mgdAttrAttackResult)
-!mmm   if isdenied(attackResult) or isunknown(attackResult)
-!mmm     do whisperback("Access to attack result value failed: " & getreason(attackResult))
-!mmm     exit script
-!mmm   end if
-!mmm   set criticalAttack = (m3mgdExchange.(m3mgdAttrAttackResult).max eq "true")
-!mmm   if criticalAttack == true
+!mmm   set attackerID = attackData.origin
+!mmm   set attackResult = attackData.attackResult
+!mmm   if attackData.criticalAttack == true
 !mmm     set attackResult = highlight(attackResult, "good", "Übergeben von " & attackerID.name)
 !mmm   else 
 !mmm     set attackResult = highlight(attackResult, "normal", "Übergeben von " & attackerID.name)
@@ -48,7 +59,7 @@
 !mmm   set defenseResult = defenseRoll + (cTargetID.Abwehr + round(cTargetID.St / 5))
 !mmm   set defenseResult = highlight(defenseResult, default, "= 🎲" & defenseRoll & " + Abwehr:" & cTargetID.Abwehr & " + St/5:" & round(cTargetID.St / 5))
 !mmm   
-!mmm   if iscritical(defenseRoll) or (criticalAttack == false and defenseResult >= attackResult)
+!mmm   if iscritical(defenseRoll) or (attackData.criticalAttack == false and defenseResult >= attackResult)
 !mmm     
 !mmm     set defenseSuccess = true 
 !mmm

--- a/examples/midgard/defense/defendSnatch.mmm
+++ b/examples/midgard/defense/defendSnatch.mmm
@@ -5,7 +5,7 @@
 !mmm   set cTargetID = "@{target|Angriffsziel|token_id}"
 !mmm end customize
 !mmm script
-!mmm   set scriptVersion = "defendSnatch 1.3.0 (2025-04-16)"
+!mmm   set scriptVersion = "defendSnatch 1.3.0 (2025-04-20)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -44,7 +44,6 @@
 !mmm       do whisperback(m3mgdExchangeAssignAttack(m3mgdExchangeRegistries.combatData, { action: "combatAttack", attackType: "magic", magicSpell: "Snatch" }, cOwnID))
 !mmm       exit script
 !mmm     end if
-!mmm     debug chat: Identified a single dataset that fits: ${attackData}
 !mmm   end if
 !mmm   
 !mmm   set attackerID = attackData.origin

--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "defense 2.1.1 (2025-03-12)"
+!mmm   set scriptVersion = "defense 2.2.0 (2025-04-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -27,10 +27,10 @@
 !rem   //
 !mmm   if selected and sender.token_id ne selected and m3mgdValidateOwnTokenID(selected.token_id)
 !mmm     set customizable cOwnID = selected.token_id
-!mmm   else if m3mgdExchange.(m3mgdAttrAttackTargetID) ne "" and m3mgdValidateOwnTokenID(m3mgdExchange.(m3mgdAttrAttackTargetID))
-!mmm     set customizable cOwnID = m3mgdExchange.(m3mgdAttrAttackTargetID)
 !mmm   else if m3mgdValidateOwnTokenID(sender.token_id)
 !mmm     set customizable cOwnID = sender.token_id
+!mmm   else
+!mmm     set customizable cOwnID = default
 !mmm   end if
 !mmm   set customizable cWeaponLabel = ""
 !rem
@@ -71,12 +71,11 @@
 !mmm     set payload = payload & "&#x25;{MacroSheet|defense}"
 !mmm     do whisperback("<" & "br>Wer soll sich denn verteidigen?<" & "br>[**Token auswählen**](" & payload & ")")
 !mmm     exit script
-!mmm   else if not m3mgdValidateAttackData()
-!mmm     chat: /w "${cOwnID.character_name}" ${"<"}br>Abwehrskript: Angriffsdaten unvollständig oder ungültig${"<"}br>[**Angriffsdaten eingeben**](${m3mgdDefenseDataEntryPayload(cOwnID)})
-!mmm     exit script
 !mmm   end if
-!mmm   if not m3mgdExchange.(m3mgdAttrAttackTargetID) eq cOwnID
-!mmm     chat: /w "${cOwnID.character_name}" ${"<"}br>Abwehrskript: ${m3mgdExchange.(m3mgdAttrAttackTargetID).name} wurde zuletzt angegriffen, nicht ich.${"<"}br>[**Angriffsdaten eingeben**](${m3mgdDefenseDataEntryPayload(cOwnID)})
+!mmm   set attackData = m3mgdRetrieveAttack(cOwnID)
+!mmm   if not attackData
+!mmm     chat: /w "${cOwnID.character_name}" ${"<"}br>Abwehrskript: Angriffsdaten unvollständig oder ungültig${"<"}br>[**Angriffsdaten eingeben**](${m3mgdDefenseDataEntryPayload(cOwnID)})
+!mmm     debug chat: ${attackData}
 !mmm     exit script
 !mmm   end if
 !rem
@@ -84,24 +83,18 @@
 !mmm   set modifierLog = ""
 !mmm   set modifierTooltip = ""
 !mmm
-!mmm   set attackerID = m3mgdExchange.(m3mgdAttrAttackerID)
-!mmm   set attackType = m3mgdExchange.(m3mgdAttrAttackType)
-!mmm   set attackResult = m3mgdExchange.(m3mgdAttrAttackResult)
-!mmm   set criticalAttack = (m3mgdExchange.(m3mgdAttrAttackResult).max eq "true")
-!mmm   set attackDamage = m3mgdExchange.(m3mgdAttrAttackDamage)
-!mmm   set attackDamageRoll = m3mgdExchange.(m3mgdAttrAttackDamageRoll)
-!mmm   set attackWeaponType = m3mgdExchange.(m3mgdAttrAttackWeaponType)
 !mmm   set defenseProperty = "Abwehr"
 !mmm   set defensePropertyBonus = "BonusAbwehr"
 !rem   // Special case: magic weapons or weapon spells with additional effects scripts whose name is stored in .max
-!mmm   if m3mgdExchange.(m3mgdAttrAttackWeaponType).max ne ""
-!mmm     set attackWeaponSpecialEffect = m3mgdExchange.(m3mgdAttrAttackWeaponType).max
+!mmm   if attackData.weaponType[1] ne ""
+!mmm     set attackWeaponSpecialEffect = attackData.weaponType[1]
 !mmm   end if
 !rem   // Special case: magic spells whose name is stored in attack_type.max
-!mmm   if m3mgdExchange.(m3mgdAttrAttackType).max ne ""
-!mmm     set attackSpell = m3mgdExchange.(m3mgdAttrAttackType).max
-!mmm     set attackEnduranceCost = m3mgdExchange.(m3mgdAttrAttackEnduranceCost)
-!mmm     set attackSpellType = attackWeaponType
+!rem   // TODO
+!mmm   if attackData.magicSpell
+!mmm     set attackSpell = attackData.magicSpell
+!mmm     set attackEnduranceCost = attackData.spellEnduranceCost
+!mmm     set attackSpellType = attackData.spellType
 !mmm     if attackSpellType eq "Geist"
 !mmm       set defenseProperty = "ResGeist"
 !mmm       set defensePropertyBonus = "BonusResG"
@@ -146,7 +139,7 @@
 !rem     // Not helpless, so let's prep for the big defense!
 !rem
 !rem     // Validate defense weapon, default to the only one or request manual entry
-!mmm     if cWeaponLabel eq "" and not attackType eq "magic"
+!mmm     if cWeaponLabel eq "" and not attackData.attackType eq "magic"
 !mmm       set defenseWeaponList = m3mgdListDefenseWeapons(cOwnID)
 !mmm       if not defenseWeaponList
 !mmm         do whisperback("Fehler im Charakterbogen: " & cOwnID.name & " hat keine Abwehrwaffen bzw. -fähigkeiten.")
@@ -154,7 +147,7 @@
 !mmm       else if count(defenseWeaponList) == 1
 !mmm         set cWeaponLabel = cOwnID.(defenseWeaponList)
 !mmm       else 
-!mmm         chat: /w "${cOwnID.character_name}" ${m3mgdWeaponSelectorChatMenu(cOwnID, "defense", attackWeaponType)}
+!mmm         chat: /w "${cOwnID.character_name}" ${m3mgdWeaponSelectorChatMenu(cOwnID, "defense", attackData.weaponType)}
 !mmm         exit script
 !mmm       end if
 !mmm     end if
@@ -162,12 +155,12 @@
 !rem     // If user wants to use a parry weapon/shield, validate
 !mmm     set parryWeaponUsable = false
 !mmm     set parryWeapon = (cOwnID.(findattr(cOwnID, "Abwehr", "AbwWaffe", cWeaponLabel, "FWAbwWaffe")) > 0)
-!mmm     if parryWeapon and not attackType eq "magic"
+!mmm     if parryWeapon and not attackData.attackType eq "magic"
 !mmm       if m3mgdParryLargeShieldTypes where ... eq cWeaponLabel 
 !mmm         set parryWeaponUsable = true
-!mmm       else if (m3mgdParrySmallShieldTypes where ... eq cWeaponLabel) and (m3mgdParrySmallShieldEffectiveAgainst where ... eq attackWeaponType)
+!mmm       else if (m3mgdParrySmallShieldTypes where ... eq cWeaponLabel) and (m3mgdParrySmallShieldEffectiveAgainst where ... eq attackData.weaponType)
 !mmm         set parryWeaponUsable = true
-!mmm       else if (m3mgdParryStandardTypes where ... eq cWeaponLabel) and (m3mgdParryStandardEffectiveAgainst where ... eq attackWeaponType)
+!mmm       else if (m3mgdParryStandardTypes where ... eq cWeaponLabel) and (m3mgdParryStandardEffectiveAgainst where ... eq attackData.weaponType)
 !mmm         set parryWeaponUsable = true
 !mmm       end if
 !rem       // If shield/parry weapon accessible and endurance > 0, check applicability and calculate defense benefits
@@ -178,11 +171,11 @@
 !mmm         set effDefense = effDefense + effParryWeaponSkill
 !mmm         set modifierLog = modifierLog & " {{" & cWeaponLabel & "= WW inkl. +" & effParryWeaponSkill & ", AP-Verlust (leichte Treffer) -" & parryWeaponEnduranceProtection & "}}"
 !mmm       else if not parryWeaponUsable
-!mmm         set modifierLog = modifierLog & " {{" & cWeaponLabel & "= nutzlos gegen " & attackWeaponType & "}}"
+!mmm         set modifierLog = modifierLog & " {{" & cWeaponLabel & "= nutzlos gegen " & attackData.weaponType & "}}"
 !mmm       else
 !mmm         set modifierLog = modifierLog & " {{" & cWeaponLabel & "= nutzlos: bin erschöpft (AP=0)}}"
 !mmm       end if
-!mmm     else if not (cWeaponLabel eq cOwnID.(findattr(cOwnID, "Abwehr", "AbwWaffe", cWeaponLabel, "AbwWaffe"))) and not attackType eq "magic"
+!mmm     else if not (cWeaponLabel eq cOwnID.(findattr(cOwnID, "Abwehr", "AbwWaffe", cWeaponLabel, "AbwWaffe"))) and not attackData.attackType eq "magic"
 !rem       // Script was called for a parry weapon that was not found in the character sheet
 !mmm       set modifierLog = modifierLog & " {{" & cWeaponLabel & "= nicht im Charakterblatt}}"
 !mmm       set cWeaponLabel = ""
@@ -239,16 +232,16 @@
 !mmm   set effEnduranceLoss = 0
 !mmm   set effHealthLoss = 0
 !mmm
-!mmm   if not cNoDefense and ((not criticalAttack and ((defenseResult >= attackResult and not isfumble(cDefenseRoll)) or iscritical(cDefenseRoll))) or (criticalAttack and iscritical(cDefenseRoll)))
+!mmm   if not cNoDefense and ((not attackData.criticalAttack and ((defenseResult >= attackData.attackResult and not isfumble(cDefenseRoll)) or iscritical(cDefenseRoll))) or (attackData.criticalAttack and iscritical(cDefenseRoll)))
 !mmm
 !rem     // Defense successful
 !mmm     set defenseSuccess = true
 !mmm
 !rem     // Calculate endurance damage (only for max endurance > 0; may be reduced due to parry weapon or shield properties)
 !mmm     if not cOwnID.(cEnduranceAttr).max == 0 and parryWeaponEnduranceProtection
-!mmm       set effEnduranceLoss = zeroOrPositive(attackDamage - parryWeaponEnduranceProtection)
+!mmm       set effEnduranceLoss = zeroOrPositive(attackData.damageResult - parryWeaponEnduranceProtection)
 !mmm     else if not cOwnID.(cEnduranceAttr).max == 0
-!mmm       set effEnduranceLoss = attackDamage
+!mmm       set effEnduranceLoss = attackData.damageResult
 !mmm     end if
 !mmm
 !mmm   else 
@@ -257,25 +250,25 @@
 !mmm     set defenseSuccess = false
 !mmm
 !rem     // Critically successful magic attacks
-!mmm     if attackSpell and criticalAttack and defenseResult < 20
-!mmm       set attackDamage = attackDamage * 2
-!mmm     else if attackSpell and criticalAttack and not isfumble(cDefenseRoll) and attackEnduranceCost >= 2
-!mmm       set attackerNewEndurance = m3mgdModifyEndurance(floor(attackEnduranceCost / 2), attackerID)
+!mmm     if attackSpell and attackData.criticalAttack and defenseResult < 20
+!mmm       set attackData = {attackData, damageResult: attackData.damageResult * 2 }
+!mmm     else if attackSpell and attackData.criticalAttack and not isfumble(cDefenseRoll) and attackEnduranceCost >= 2
+!mmm       set attackerNewEndurance = m3mgdModifyEndurance(floor(attackEnduranceCost / 2), attackData.origin)
 !mmm     end if
 !mmm
 !rem     // Defender loses full hit points worth of endurance regardless of armor, if not an undead creature with unlimited endurance
 !mmm     if not cOwnID.(cEnduranceAttr).max == 0
-!mmm       set effEnduranceLoss = attackDamage
+!mmm       set effEnduranceLoss = attackData.damageResult
 !mmm     else 
 !mmm       set effEnduranceLoss = 0
 !mmm     end if
 !mmm
 !rem     // Calculate damage to health depending on armor (only for max health > 0, ghosts do not lose health, armor does not work against direct magic attacks)
-!mmm     set effArmorProtection = m3mgdEffectiveArmorProtection(cOwnID, attackWeaponType, attackType)
+!mmm     set effArmorProtection = m3mgdEffectiveArmorProtection(cOwnID, attackData.weaponType, attackData.attackType)
 !mmm     if not cOwnID.(cHealthAttr).max == 0 and effArmorProtection
-!mmm       set effHealthLoss = zeroOrPositive(attackDamage - effArmorProtection)
+!mmm       set effHealthLoss = zeroOrPositive(attackData.damageResult - effArmorProtection)
 !mmm     else if not cOwnID.(cHealthAttr).max == 0
-!mmm       set effHealthLoss = attackDamage
+!mmm       set effHealthLoss = attackData.damageResult
 !mmm     end if
 !mmm   end if
 !mmm
@@ -296,15 +289,15 @@
 !mmm   end if
 !rem
 !rem   // Process experience gain for attacker if script is run on an NPC, in which case player is GM with control over attacker sheet
-!mmm   if isChar(attackerID) and not cNoDefense and ((cOwnID.(cEnduranceAttr).max == 0 and not defenseSuccess) or (cOwnID.(cEnduranceAttr).max != 0 and endurance > 0 and effEnduranceLoss > 0))
-!mmm     set xpGain = m3mgdProcessAttackXP(m3mgdExchange.(m3mgdAttrAttackType), attackDamageRoll, attackerID, cOwnID)
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackerID.name & ": +" & xpGain & " EP}} "
+!mmm   if isChar(attackData.origin) and not cNoDefense and ((cOwnID.(cEnduranceAttr).max == 0 and not defenseSuccess) or (cOwnID.(cEnduranceAttr).max != 0 and endurance > 0 and effEnduranceLoss > 0))
+!mmm     set xpGain = m3mgdProcessAttackXP(m3mgdExchange.(m3mgdAttrAttackType), attackData.damageRoll, attackData.origin, cOwnID)
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": +" & xpGain & " EP}} "
 !mmm   else if not cNoDefense and cOwnID.(cEnduranceAttr).max == 0 and defenseSuccess
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackerID.name & ": keine (∞ AP, abgewehrt) }} "
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": keine (∞ AP, abgewehrt) }} "
 !mmm   else if cNoDefense or (cOwnID.(cEnduranceAttr).max != 0 and endurance <= 0)
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackerID.name & ": keine (Ziel erschöpft/wehrlos) }} "
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": keine (Ziel erschöpft/wehrlos) }} "
 !mmm   else if cOwnID.(cEnduranceAttr).max != 0 and effEnduranceLoss <= 0
-!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackerID.name & ": keine (kein AP-Verlust) }} "
+!mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": keine (kein AP-Verlust) }} "
 !mmm   end if
 !mmm
 !rem   // Register practice point, if applicable
@@ -327,7 +320,7 @@
 !mmm           chat     [OngoingCriticalInjury]:    ***Ich bin immer noch lebensgefährlich verletzt, mein Countdown läuft weiter.*** [x](https://media.giphy.com/media/OY9XK7PbFqkNO/giphy.gif) ***Jetzt könnte ich eine heilende Hand gebrauchen...***
 !mmm         end if
 !mmm       else
-!mmm         if criticalAttack
+!mmm         if attackData.criticalAttack
 !mmm           chat     [DefenseFailureCritDamage]: Mich erwischt ein schwerer **kritischer Treffer**.
 !mmm         else 
 !mmm           chat     [DefenseFailureRegDamage]:  Mich erwischt ein schwerer Treffer.
@@ -353,7 +346,7 @@
 !mmm   end if
 !rem
 !rem   // Output data table using data table execution code from library
-!mmm   do m3mgdDefenseDataTable()
+!mmm   do m3mgdDefenseDataTable(attackData)
 !mmm
 !rem   // If present, reduce counters for defense-specific modifier effects
 !mmm   set endOfActionSummary = m3mgdUpdatePersistentEffectsCounters(cOwnID, "defense")
@@ -369,7 +362,7 @@
 !mmm   
 !rem   // Weapon-specific special damage effects
 !mmm   if not defenseSuccess and attackWeaponSpecialEffect
-!mmm     do m3mgdWeaponSpecialEffect(attackWeaponSpecialEffect, attackerID)
+!mmm     do m3mgdWeaponSpecialEffect(attackWeaponSpecialEffect, attackData.origin)
 !mmm   end if
 !mmm
 !rem   // Injury & exhaustion special effects

--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "defense 2.2.0-pre1 (2025-04-17)"
+!mmm   set scriptVersion = "defense 2.2.0-pre2 (2025-04-19)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -90,7 +90,6 @@
 !mmm     set attackWeaponSpecialEffect = attackData.weaponType[1]
 !mmm   end if
 !rem   // Special case: magic spells whose name is stored in attack_type.max
-!rem   // TODO
 !mmm   if attackData.magicSpell
 !mmm     set attackSpell = attackData.magicSpell
 !mmm     set attackEnduranceCost = attackData.spellEnduranceCost
@@ -115,7 +114,7 @@
 !mmm   set attackerLog = m3mgdProcessAttackerEffects(attackData)
 !mmm   if attackerLog 
 !mmm     combine chat
-!mmm       chat: /w "${attackData.origin.character_name}" ${"&"}{template:default} {{name=Kosten des Angriffs auf ${attackData.target.name}}}
+!mmm       chat: /w "${attackData.origin.character_name}" ${"&"}{template:default} {{name=${attackData.origin.name}: Kosten des Angriffs auf ${attackData.target.name}}}
 !mmm       for logline in attackerLog...
 !mmm         chat: {{ ${logline.key}=${logline.value} }}
 !mmm       end for

--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "defense 2.2.0 (2025-04-16)"
+!mmm   set scriptVersion = "defense 2.2.0-pre1 (2025-04-17)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -109,6 +109,17 @@
 !mmm       exit script
 !mmm     end if
 !mmm     set modifierLog = modifierLog & " {{ Zauberei = Verteidigung mit **" & defenseProperty & "** (" & cOwnID.(defenseProperty) & "+" & cOwnID.(defensePropertyBonus) & ") }}"
+!mmm   end if
+!mmm
+!rem   // Process effects on attacker (after GM approval)
+!mmm   set attackerLog = m3mgdProcessAttackerEffects(attackData)
+!mmm   if attackerLog 
+!mmm     combine chat
+!mmm       chat: /w "${attackData.origin.character_name}" ${"&"}{template:default} {{name=Kosten des Angriffs auf ${attackData.target.name}}}
+!mmm       for logline in attackerLog...
+!mmm         chat: {{ ${logline.key}=${logline.value} }}
+!mmm       end for
+!mmm     end combine
 !mmm   end if
 !mmm
 !rem   // Initialize defender 
@@ -290,7 +301,7 @@
 !rem
 !rem   // Process experience gain for attacker if script is run on an NPC, in which case player is GM with control over attacker sheet
 !mmm   if isChar(attackData.origin) and not cNoDefense and ((cOwnID.(cEnduranceAttr).max == 0 and not defenseSuccess) or (cOwnID.(cEnduranceAttr).max != 0 and endurance > 0 and effEnduranceLoss > 0))
-!mmm     set xpGain = m3mgdProcessAttackXP(m3mgdExchange.(m3mgdAttrAttackType), attackData.damageRoll, attackData.origin, cOwnID)
+!mmm     set xpGain = m3mgdProcessAttackXP(attackData.attackType, attackData.damageRoll, attackData.origin, cOwnID)
 !mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": +" & xpGain & " EP}} "
 !mmm   else if not cNoDefense and cOwnID.(cEnduranceAttr).max == 0 and defenseSuccess
 !mmm     set modifierLog = modifierLog & " {{ Erfahrung=" & attackData.origin.name & ": keine (∞ AP, abgewehrt) }} "

--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Combat Defense Script
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "defense 2.2.0-pre2 (2025-04-19)"
+!mmm   set scriptVersion = "defense 2.2.0 (2025-04-19)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion

--- a/examples/midgard/defense/defense.mmm
+++ b/examples/midgard/defense/defense.mmm
@@ -373,7 +373,7 @@
 !mmm   
 !rem   // Weapon-specific special damage effects
 !mmm   if not defenseSuccess and attackWeaponSpecialEffect
-!mmm     do m3mgdWeaponSpecialEffect(attackWeaponSpecialEffect, attackData.origin)
+!mmm     do m3mgdWeaponSpecialEffect(attackWeaponSpecialEffect, attackData.origin, attackData.target)
 !mmm   end if
 !mmm
 !rem   // Injury & exhaustion special effects

--- a/examples/midgard/libMidgardGlobal/initGameGlobals.mmm
+++ b/examples/midgard/libMidgardGlobal/initGameGlobals.mmm
@@ -3,7 +3,7 @@
 !rem //   defines game-global variables and loads global functions for use across Midgard scripts
 !rem // 
 !mmm script
-!mmm   set scriptVersion = "initGameGlobals 1.3.1 (2024-04-24)"
+!mmm   set scriptVersion = "initGameGlobals 1.4.0 (2025-04-16)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !mmm   set customizable cCheckVersion = false
@@ -26,6 +26,9 @@
 !mmm   
 %{MacroSheetLibrary|libMidgard}
 !mmm   do _libMidgard()
+!mmm   
+%{MacroSheetLibrary|libExchange}
+!mmm   do _libExchange()
 !mmm   
 %{MacroSheetLibrary|libMidgardRuneBlades}
 !mmm   do _libMidgardRuneBlades()

--- a/examples/midgard/libMidgardGlobal/libBasics.mmm
+++ b/examples/midgard/libMidgardGlobal/libBasics.mmm
@@ -6,7 +6,7 @@
 !rem //
 !mmm function _libBasics()
 !mmm   
-!mmm   set libVersion = "libMidgardBasics v1.4.4 (2024-08-11)"
+!mmm   set libVersion = "libMidgardBasics v1.4.5 (2025-03-16)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Brute-force build a dictionary of maximum roll results
@@ -290,6 +290,7 @@
 !mmm end function
 !rem
 !rem // chatTightBoxButtonSubHeader(label, tooltip, payload, bgColor, textColor)
+!rem //   WARNING: payload MUST NOT CONTAIN any colons (":"), neither literally nor escaped ("\:") or run through MMM's literal() function.
 !rem //
 !mmm function chatTightBoxButtonSubHeader(label, tooltip, payload, bgColor, textColor)
 !mmm   if isdefault(bgColor)
@@ -310,6 +311,7 @@
 !mmm end function
 !rem
 !rem // chatTightBoxButtonRow(label, tooltip, payload, bgColor, textColor)
+!rem //   WARNING: payload MUST NOT CONTAIN any colons (":"), neither literally nor escaped ("\:") or run through MMM's literal() function.
 !rem //
 !mmm function chatTightBoxButtonRow(label, tooltip, payload, bgColor, textColor)
 !mmm   if isdefault(bgColor)
@@ -330,6 +332,7 @@
 !mmm end function
 !rem
 !rem // chatTightBoxFlowButton(label, tooltip, payload, bgColor, textColor)
+!rem //   WARNING: payload MUST NOT CONTAIN any colons (":"), neither literally nor escaped ("\:") or run through MMM's literal() function.
 !rem //
 !mmm function chatTightBoxFlowButton(label, tooltip, payload, bgColor, textColor)
 !mmm   if isdefault(bgColor)
@@ -353,6 +356,7 @@
 !rem //
 !rem //   Returns Roll20 chat code for a series of buttons defined by the list of structs { label, payload, [bgColor, textColor] } provided as buttons.
 !rem //   CSS display is set to inline, so if the number is small and the labels are short, they should fit in a single row.
+!rem //   WARNING: payload MUST NOT CONTAIN any colons (":"), neither literally nor escaped ("\:") or run through MMM's literal() function.
 !rem //
 !mmm function chatTightBoxMultiButton(buttons)
 !mmm   set gap = '[&nbsp;](#\" style=\"display:block;margin:0px;padding:0px;font-size:5px;border:none)'

--- a/examples/midgard/libMidgardGlobal/libExchange.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchange.mmm
@@ -6,19 +6,18 @@
 !rem //
 !mmm function _libExchange()
 !mmm   
-!mmm   set libVersion = "libExchange v1.0-pre2 (2025-04-19)"
+!mmm   set libVersion = "libExchange v1.0 (2025-04-21)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Define character sheet to use as central storage (for now, this happens already in _libMidgard)
-!rem   //set m3mgdExchangeDataSheet = "MacroSheet"
-!rem   //set m3mgdExchange = m3mgdExchangeDataSheet.character_id
 !mmm   set m3mgdExchangeRegistries = { combatData: "m3mgdCombatData", activePersistentEffects: "m3mgdActivePersistentEffects" }
-!rem
-!mmm   if m3mgdExchange.permission ne "view" and m3mgdExchange.permission ne "control" 
-!mmm     do whisperback(libVersion & " - No permission to access Midgard data exchange sheet '" & m3mgdExchangeDataSheet & "'. Data exchange will not work.")
-!mmm     do delay(5)
-!mmm     return false
-!mmm   end if
+!mmm   for dataRegistry in m3mgdExchangeRegistries...
+!mmm     if dataRegistry.value.permission ne "view" and dataRegistry.value.permission ne "control" 
+!mmm       do whisperback(libVersion & " - No permission to access Midgard data exchange sheet '" & m3mgdExchangeDataSheet & "'. Data exchange will not work.")
+!mmm       do delay(5)
+!mmm       return false
+!mmm     end if
+!mmm   end for
 !mmm
 !mmm   set m3mgdScriptCommands = { m3mgdScriptCommands, exchangeRegEdit: "&#x25;{MacroSheet|exchangeRegEdit}" }
 !mmm   publish to game: m3mgdScriptCommands

--- a/examples/midgard/libMidgardGlobal/libExchange.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchange.mmm
@@ -6,19 +6,22 @@
 !rem //
 !mmm function _libExchange()
 !mmm   
-!mmm   set libVersion = "libExchange v0.4 WIP (2025-04-03)"
+!mmm   set libVersion = "libExchange v0.5-WIP3 (2025-04-16)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Define character sheet to use as central storage (for now, this happens already in _libMidgard)
 !rem   //set m3mgdExchangeDataSheet = "MacroSheet"
 !rem   //set m3mgdExchange = m3mgdExchangeDataSheet.character_id
-!mmm   set m3mgdExchangeRegistries = "m3mgdCombatData", "m3mgdActivePersistentEffects"
+!mmm   set m3mgdExchangeRegistries = { combatData: "m3mgdCombatData", activePersistentEffects: "m3mgdActivePersistentEffects" }
 !rem
 !mmm   if m3mgdExchange.permission ne "view" and m3mgdExchange.permission ne "control" 
 !mmm     do whisperback(libVersion & " - No permission to access Midgard data exchange sheet '" & m3mgdExchangeDataSheet & "'. Data exchange will not work.")
 !mmm     do delay(5)
 !mmm     return false
 !mmm   end if
+!mmm
+!mmm   set m3mgdScriptCommands = { m3mgdScriptCommands, exchangeRegEdit: "&#x25;{MacroSheet|exchangeRegEdit}" }
+!mmm   publish to game: m3mgdScriptCommands
 !mmm
 !rem   // Publish game-global variables defined below
 !rem
@@ -27,7 +30,8 @@
 !rem
 !rem   // Publish game-global functions defined below
 !rem
-!mmm   publish to game: m3mgdExchangeFlushRegistry, m3mgdExchangeGetRegistry, m3mgdExchangeStoreEntry, m3mgdExchangeGetData, m3mgdExchangeDeleteEntry
+!mmm   publish to game: m3mgdExchangeFlushRegistry, m3mgdExchangeGetRegistry, m3mgdExchangeStoreEntry, m3mgdExchangeGetData, m3mgdExchangeDelete
+!mmm   publish to game: m3mgdExchangeStoreAttack
 !mmm   publish to game: m3mgdExchangeRegEdit
 !mmm
 !mmm   chat: ${libVersion} loaded.
@@ -80,7 +84,7 @@
 !mmm     set registry = m3mgdExchangeGetRegistry(registryID), entry
 !mmm   end if
 !mmm
-!mmm   debug do registry
+!mmm   debug do registry, registryID
 !mmm
 !mmm   set serialRegistry = serialize(registry)
 !mmm   return (setattr(m3mgdExchange, registryID, serialRegistry) eq serialRegistry)
@@ -123,11 +127,11 @@
 !mmm
 !mmm end function
 !rem 
-!rem // m3mgdExchangeDeleteEntry(registryID, searchCriteria)
+!rem // m3mgdExchangeDelete(registryID, searchCriteria)
 !rem // 
 !rem //   Deletes one or several entries from a central data registry, identified by the searchCriteria provided (all at the same time/AND).
 !rem // 
-!mmm function m3mgdExchangeDeleteEntry(registryID, searchCriteria)
+!mmm function m3mgdExchangeDelete(registryID, searchCriteria)
 !mmm
 !mmm   if isdenied(m3mgdExchange.(registryID))
 !mmm     debug chat: m3mgdExchangeDeleteEntry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.

--- a/examples/midgard/libMidgardGlobal/libExchange.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchange.mmm
@@ -6,7 +6,7 @@
 !rem //
 !mmm function _libExchange()
 !mmm   
-!mmm   set libVersion = "libExchange v1.0-WIP3 (2025-04-16)"
+!mmm   set libVersion = "libExchange v1.0-pre (2025-04-16)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Define character sheet to use as central storage (for now, this happens already in _libMidgard)
@@ -30,7 +30,7 @@
 !rem
 !rem   // Publish game-global functions defined below
 !rem
-!mmm   publish to game: m3mgdExchangeFlushRegistry, m3mgdExchangeGetRegistry, m3mgdExchangeStoreEntry, m3mgdExchangeGetData, m3mgdExchangeDelete, m3mgdExchangeEditEntry
+!mmm   publish to game: m3mgdExchangeFlushRegistry, m3mgdExchangeGetRegistry, m3mgdExchangeStoreEntry, m3mgdExchangeGetData, m3mgdExchangeDelete, m3mgdExchangeEdit
 !mmm   publish to game: m3mgdExchangeRegEdit, m3mgdExchangeAssignAttack
 !mmm
 !mmm   chat: ${libVersion} loaded.
@@ -159,17 +159,17 @@
 !mmm
 !mmm end function
 !rem 
-!rem // m3mgdExchangeEditEntry(registryID, searchCriteria, newData)
+!rem // m3mgdExchangeEdit(registryID, searchCriteria, newData)
 !rem // 
-!rem //   Changes an entry by overwriting relevant fields with newData.
+!rem //   Changes all entries that match the given searchCriteria by overwriting relevant fields with newData.
 !rem // 
-!mmm function m3mgdExchangeEditEntry(registryID, searchCriteria, newData)
+!mmm function m3mgdExchangeEdit(registryID, searchCriteria, newData)
 !mmm
 !mmm   if isdenied(m3mgdExchange.(registryID))
-!mmm     debug chat: m3mgdExchangeEditEntry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     debug chat: m3mgdExchangeEdit(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   else if not m3mgdExchange.(registryID)
-!mmm     debug chat: m3mgdExchangeEditEntry(): data exchange registry ${registryID} empty/non-existant => nothing to edit. Aborting.
+!mmm     debug chat: m3mgdExchangeEdit(): data exchange registry ${registryID} empty/non-existant => nothing to edit. Aborting.
 !mmm     return false
 !mmm   end if
 !mmm
@@ -177,7 +177,7 @@
 !mmm   for entry in registry
 !mmm     set match = false
 !mmm     for rule in searchCriteria...
-!mmm       if entry.(rule.key) eq rule.value
+!mmm       if isdefault(rule.value) or entry.(rule.key) eq rule.value
 !mmm         set match = true
 !mmm       else
 !mmm         set match = false
@@ -187,16 +187,23 @@
 !mmm     if match
 !mmm       set newEntry = { entry, newData }
 !mmm       set newRegistry = newRegistry, newEntry
+!mmm       set modifiedEntries = { modifiedEntries, newEntry }
 !mmm     else
 !mmm       set newRegistry = newRegistry, entry
 !mmm     end if
 !mmm   end for
 !mmm
-!mmm   debug chat: modified entry, new state: ${newEntry}
-!mmm   set serialRegistry = serialize(newRegistry)
-!mmm   if setattr(m3mgdExchange, registryID, serialRegistry) eq serialRegistry
-!mmm     return newEntry
+!mmm   if match
+!mmm     set serialRegistry = serialize(newRegistry)
+!mmm     if setattr(m3mgdExchange, registryID, serialRegistry) eq serialRegistry
+!mmm       debug chat: Changes saved: ${modifiedEntries}
+!mmm       return modifiedEntries
+!mmm     else
+!mmm       debug chat: Unable to save changes: ${modifiedEntries}
+!mmm       return false
+!mmm     end if
 !mmm   else
+!mmm     debug chat: No match, no change for criteria ${searchCriteria} with new data ${newData}.
 !mmm     return false
 !mmm   end if
 !mmm

--- a/examples/midgard/libMidgardGlobal/libExchange.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchange.mmm
@@ -6,7 +6,7 @@
 !rem //
 !mmm function _libExchange()
 !mmm   
-!mmm   set libVersion = "libExchange v0.2 WIP (2025-03-13)"
+!mmm   set libVersion = "libExchange v0.3 WIP (2025-03-16)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Define character sheet to use as central storage (for now, this happens already in _libMidgard)
@@ -40,8 +40,8 @@
 !rem // 
 !mmm function m3mgdExchangeFlushRegistry(registryID)
 !mmm
-!mmm   if not m3mgdExchange.(registryID)
-!mmm     debug chat: m3mgdExchangeFlushRegistry(): attribute m3mgdExchange.${registryID} not found or not accessible. Aborting.
+!mmm   if isdenied(m3mgdExchange.(registryID))
+!mmm     debug chat: m3mgdExchangeFlushRegistry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   end if
 !mmm
@@ -65,8 +65,14 @@
 !rem // 
 !mmm function m3mgdExchangeStoreEntry(registryID, entry)
 !mmm
-!mmm   if not m3mgdExchange.(registryID) and isdenied(m3mgdExchange.(registryID))
+!mmm   if isdenied(m3mgdExchange.(registryID))
 !mmm     debug chat: m3mgdExchangeStoreEntry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     return false
+!mmm   else if isunknown(entry.origin.character_id) or isdenied(entry.origin.character_id)
+!mmm     debug chat: m3mgdExchangeStoreEntry(): cannot store data with unknown or denied reference for **origin** token/character: ${entry.origin} Aborting.
+!mmm     return false
+!mmm   else if isunknown(entry.target.character_id) or isdenied(entry.target.character_id)
+!mmm     debug chat: m3mgdExchangeStoreEntry(): cannot store data with unknown or denied reference for **target** token/character: ${entry.target} Aborting.
 !mmm     return false
 !mmm   else if not m3mgdExchange.(registryID)
 !mmm     set registry = entry
@@ -88,10 +94,14 @@
 !rem // 
 !mmm function m3mgdExchangeGetData(registryID, searchCriteria)
 !mmm
-!mmm   if not m3mgdExchange.(registryID)
-!mmm     debug chat: m3mgdExchangeGetData(): attribute m3mgdExchange.${registryID} not found or not accessible. Aborting.
+!mmm   if isdenied(m3mgdExchange.(registryID))
+!mmm     debug chat: m3mgdExchangeGetData(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   end if
+!mmm
+!mmm   if isdefault(searchCriteria)
+!mmm     return m3mgdExchangeGetRegistry(registryID)
+!mmm   end if 
 !mmm
 !mmm   set registry = m3mgdExchangeGetRegistry(registryID)
 !mmm   for entry in registry
@@ -119,8 +129,11 @@
 !rem // 
 !mmm function m3mgdExchangeDeleteEntry(registryID, searchCriteria)
 !mmm
-!mmm   if not m3mgdExchange.(registryID)
-!mmm     debug chat: m3mgdExchangeDeleteEntry(): attribute m3mgdExchange.${registryID} not found or not accessible. Aborting.
+!mmm   if isdenied(m3mgdExchange.(registryID))
+!mmm     debug chat: m3mgdExchangeDeleteEntry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     return false
+!mmm   else if not m3mgdExchange.(registryID)
+!mmm     debug chat: m3mgdExchangeDeleteEntry(): data exchange registry ${registryID} empty/non-existant => nothing to delete. Aborting.
 !mmm     return false
 !mmm   end if
 !mmm
@@ -154,24 +167,36 @@
 !rem // 
 !mmm function m3mgdExchangeRegEdit(registryID, searchCriteria)
 !mmm
-!mmm   if not m3mgdExchange.(registryID)
-!mmm     debug chat: m3mgdExchangeRegEdit(): attribute m3mgdExchange.${registryID} not found or not accessible. Aborting.
+!mmm   if isdenied(m3mgdExchange.(registryID))
+!mmm     debug chat: m3mgdExchangeRegEdit(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   end if
 !mmm
-!mmm   do chatTightBoxHeader("m3mgdExchangeRegEdit")
+!mmm   set output = chat(chatTightBoxHeader("Datenaustausch aufräumen"))
 !mmm   for entry in m3mgdExchangeGetData(registryID, searchCriteria)
-!mmm     set outputEntry = ""
+!mmm     set outputEntry = "❌ "
 !mmm     set tooltip = ""
 !mmm     for propertyPair in entry...
-!mmm       if isunknown(propertyPair.value.token_id)
-!mmm         set outputEntry = outputEntry & " | " & propertyPair.key & ": " & propertyPair.value
+!mmm       if isunknown(propertyPair.value.token_id) or isdenied(propertyPair.value.token_id)
+!mmm         set outputEntry = outputEntry & propertyPair.key & ": **" & propertyPair.value & "** | "
 !mmm       else
-!mmm         set outputEntry = outputEntry & " | " & propertyPair.key & ": " & propertyPair.value.token_name
-!mmm         set tooltip = propertyPair.value
+!mmm         set outputEntry = outputEntry & propertyPair.key & ": **" & propertyPair.value.token_name & "** (" & propertyPair.value & ") | "
 !mmm       end if
 !mmm     end for
-!mmm     do chatTightBoxButtonRow(outputEntry, tooltip, "")
+!mmm     set tooltip = "❌ Diesen Eintrag löschen"
+!mmm     set payload = literal("!mmm customize") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set cmd=\"deleteEntry\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set deleteConfirm=true") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByAction=\"" & entry.action & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByOrigin=\"" & entry.origin & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByTarget=\"" & entry.target & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByAttackType=\"" & entry.attackType & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByAttackResult=\"" & entry.attackResult & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByDamageResult=\"" & entry.damageResult & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByMagicSpell=\"" & entry.magicSpell & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm end customize") & "&#13;" & m3mgdScriptCommands.exchangeRegEdit & "&#13;"
+!mmm     set output = output & chatTightBoxButtonRow(outputEntry, tooltip, payload)
 !mmm   end for
+!mmm   do chat(output)
 !mmm
 !mmm end function

--- a/examples/midgard/libMidgardGlobal/libExchange.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchange.mmm
@@ -6,7 +6,7 @@
 !rem //
 !mmm function _libExchange()
 !mmm   
-!mmm   set libVersion = "libExchange v0.5-WIP3 (2025-04-16)"
+!mmm   set libVersion = "libExchange v1.0-WIP3 (2025-04-16)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Define character sheet to use as central storage (for now, this happens already in _libMidgard)
@@ -30,9 +30,8 @@
 !rem
 !rem   // Publish game-global functions defined below
 !rem
-!mmm   publish to game: m3mgdExchangeFlushRegistry, m3mgdExchangeGetRegistry, m3mgdExchangeStoreEntry, m3mgdExchangeGetData, m3mgdExchangeDelete
-!mmm   publish to game: m3mgdExchangeStoreAttack
-!mmm   publish to game: m3mgdExchangeRegEdit
+!mmm   publish to game: m3mgdExchangeFlushRegistry, m3mgdExchangeGetRegistry, m3mgdExchangeStoreEntry, m3mgdExchangeGetData, m3mgdExchangeDelete, m3mgdExchangeEditEntry
+!mmm   publish to game: m3mgdExchangeRegEdit, m3mgdExchangeAssignAttack
 !mmm
 !mmm   chat: ${libVersion} loaded.
 !mmm   
@@ -75,16 +74,11 @@
 !mmm   else if isunknown(entry.origin.character_id) or isdenied(entry.origin.character_id)
 !mmm     debug chat: m3mgdExchangeStoreEntry(): cannot store data with unknown or denied reference for **origin** token/character: ${entry.origin} Aborting.
 !mmm     return false
-!mmm   else if isunknown(entry.target.character_id) or isdenied(entry.target.character_id)
-!mmm     debug chat: m3mgdExchangeStoreEntry(): cannot store data with unknown or denied reference for **target** token/character: ${entry.target} Aborting.
-!mmm     return false
 !mmm   else if not m3mgdExchange.(registryID)
 !mmm     set registry = entry
 !mmm   else
 !mmm     set registry = m3mgdExchangeGetRegistry(registryID), entry
 !mmm   end if
-!mmm
-!mmm   debug do registry, registryID
 !mmm
 !mmm   set serialRegistry = serialize(registry)
 !mmm   return (setattr(m3mgdExchange, registryID, serialRegistry) eq serialRegistry)
@@ -165,6 +159,49 @@
 !mmm
 !mmm end function
 !rem 
+!rem // m3mgdExchangeEditEntry(registryID, searchCriteria, newData)
+!rem // 
+!rem //   Changes an entry by overwriting relevant fields with newData.
+!rem // 
+!mmm function m3mgdExchangeEditEntry(registryID, searchCriteria, newData)
+!mmm
+!mmm   if isdenied(m3mgdExchange.(registryID))
+!mmm     debug chat: m3mgdExchangeEditEntry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     return false
+!mmm   else if not m3mgdExchange.(registryID)
+!mmm     debug chat: m3mgdExchangeEditEntry(): data exchange registry ${registryID} empty/non-existant => nothing to edit. Aborting.
+!mmm     return false
+!mmm   end if
+!mmm
+!mmm   set registry = m3mgdExchangeGetRegistry(registryID)
+!mmm   for entry in registry
+!mmm     set match = false
+!mmm     for rule in searchCriteria...
+!mmm       if entry.(rule.key) eq rule.value
+!mmm         set match = true
+!mmm       else
+!mmm         set match = false
+!mmm         exit for
+!mmm       end if
+!mmm     end for
+!mmm     if match
+!mmm       set newEntry = { entry, newData }
+!mmm       set newRegistry = newRegistry, newEntry
+!mmm     else
+!mmm       set newRegistry = newRegistry, entry
+!mmm     end if
+!mmm   end for
+!mmm
+!mmm   debug chat: modified entry, new state: ${newEntry}
+!mmm   set serialRegistry = serialize(newRegistry)
+!mmm   if setattr(m3mgdExchange, registryID, serialRegistry) eq serialRegistry
+!mmm     return newEntry
+!mmm   else
+!mmm     return false
+!mmm   end if
+!mmm
+!mmm end function
+!rem 
 !rem // m3mgdExchangeRegEdit(registryID, searchCriteria)
 !rem // 
 !rem //   Shows entries from a central data registry, identified by the searchCriteria provided (all at the same time/AND), and offers editing and removal.
@@ -209,5 +246,42 @@
 !mmm   end if 
 !mmm
 !mmm   do chat(output)
+!mmm
+!mmm end function
+!rem 
+!rem // m3mgdExchangeAssignAttack(registryID, searchCriteria, targetID)
+!rem // 
+!rem //   Returns chat code for a button to call the exchangeRegEdit script for a selection of entries specified by the searchCriteria provided (all at the same time/AND).
+!rem // 
+!mmm function m3mgdExchangeAssignAttack(registryID, searchCriteria, targetID)
+!mmm
+!mmm   set output = chatTightBoxHeader("Datenaustausch-Problem: Angriff auf " & targetID.name & " zuordnen")
+!mmm   set tooltip = "Diesen Angriff " & targetID.name & " zuordnen"
+!mmm   for entry in m3mgdExchangeGetData(registryID, searchCriteria)
+!mmm     set outputEntry = ""
+!mmm     for propertyPair in entry...
+!mmm       if isunknown(propertyPair.value.token_id) or isdenied(propertyPair.value.token_id)
+!mmm         set outputEntry = outputEntry & propertyPair.key & ": **" & propertyPair.value & "** | "
+!mmm       else
+!mmm         set outputEntry = outputEntry & propertyPair.key & ": **" & propertyPair.value.token_name & "** (" & propertyPair.value & ") | "
+!mmm       end if
+!mmm     end for
+!mmm     set payload = literal("!mmm customize") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set cmd=\"editEntry\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set newTarget=\"" & targetID & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByAction=\"" & entry.action & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByOrigin=\"" & entry.origin & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByAttackType=\"" & entry.attackType & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByAttackResult=\"" & entry.attackResult & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByDamageResult=\"" & entry.damageResult & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm set searchByMagicSpell=\"" & entry.magicSpell & "\"") & "&#13;"
+!mmm     set payload = payload & literal("!mmm end customize") & "&#13;" & m3mgdScriptCommands.exchangeRegEdit & "&#13;"
+!mmm     set output = output & chatTightBoxButtonRow(outputEntry, tooltip, payload)
+!mmm     set entryCount = entryCount + 1
+!mmm   end for
+!mmm   if entryCount == 0
+!mmm     set output = output & chatTightBoxRow("(keine Einträge gefunden)")
+!mmm   end if 
+!mmm   return(output)
 !mmm
 !mmm end function

--- a/examples/midgard/libMidgardGlobal/libExchange.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchange.mmm
@@ -6,7 +6,7 @@
 !rem //
 !mmm function _libExchange()
 !mmm   
-!mmm   set libVersion = "libExchange v0.1 WIP (2024-06-06)"
+!mmm   set libVersion = "libExchange v0.2 WIP (2025-03-13)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Define character sheet to use as central storage (for now, this happens already in _libMidgard)
@@ -28,6 +28,7 @@
 !rem   // Publish game-global functions defined below
 !rem
 !mmm   publish to game: m3mgdExchangeFlushRegistry, m3mgdExchangeGetRegistry, m3mgdExchangeStoreEntry, m3mgdExchangeGetData, m3mgdExchangeDeleteEntry
+!mmm   publish to game: m3mgdExchangeRegEdit
 !mmm
 !mmm   chat: ${libVersion} loaded.
 !mmm   
@@ -144,5 +145,33 @@
 !mmm   debug chat: deleting ${foundEntries}
 !mmm   set serialRegistry = serialize(survivingEntries)
 !mmm   return (setattr(m3mgdExchange, registryID, serialRegistry) eq serialRegistry)
+!mmm
+!mmm end function
+!rem 
+!rem // m3mgdExchangeRegEdit(registryID, searchCriteria)
+!rem // 
+!rem //   Shows entries from a central data registry, identified by the searchCriteria provided (all at the same time/AND), and offers editing and removal.
+!rem // 
+!mmm function m3mgdExchangeRegEdit(registryID, searchCriteria)
+!mmm
+!mmm   if not m3mgdExchange.(registryID)
+!mmm     debug chat: m3mgdExchangeRegEdit(): attribute m3mgdExchange.${registryID} not found or not accessible. Aborting.
+!mmm     return false
+!mmm   end if
+!mmm
+!mmm   do chatTightBoxHeader("m3mgdExchangeRegEdit")
+!mmm   for entry in m3mgdExchangeGetData(registryID, searchCriteria)
+!mmm     set outputEntry = ""
+!mmm     set tooltip = ""
+!mmm     for propertyPair in entry...
+!mmm       if isunknown(propertyPair.value.token_id)
+!mmm         set outputEntry = outputEntry & " | " & propertyPair.key & ": " & propertyPair.value
+!mmm       else
+!mmm         set outputEntry = outputEntry & " | " & propertyPair.key & ": " & propertyPair.value.token_name
+!mmm         set tooltip = propertyPair.value
+!mmm       end if
+!mmm     end for
+!mmm     do chatTightBoxButtonRow(outputEntry, tooltip, "")
+!mmm   end for
 !mmm
 !mmm end function

--- a/examples/midgard/libMidgardGlobal/libExchange.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchange.mmm
@@ -6,7 +6,7 @@
 !rem //
 !mmm function _libExchange()
 !mmm   
-!mmm   set libVersion = "libExchange v0.3 WIP (2025-03-16)"
+!mmm   set libVersion = "libExchange v0.4 WIP (2025-04-03)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Define character sheet to use as central storage (for now, this happens already in _libMidgard)
@@ -172,7 +172,8 @@
 !mmm     return false
 !mmm   end if
 !mmm
-!mmm   set output = chat(chatTightBoxHeader("Datenaustausch aufräumen"))
+!mmm   set output = chatTightBoxHeader("Datenaustausch aufräumen")
+!mmm   set entryCount = 0
 !mmm   for entry in m3mgdExchangeGetData(registryID, searchCriteria)
 !mmm     set outputEntry = "❌ "
 !mmm     set tooltip = ""
@@ -196,7 +197,13 @@
 !mmm     set payload = payload & literal("!mmm set searchByMagicSpell=\"" & entry.magicSpell & "\"") & "&#13;"
 !mmm     set payload = payload & literal("!mmm end customize") & "&#13;" & m3mgdScriptCommands.exchangeRegEdit & "&#13;"
 !mmm     set output = output & chatTightBoxButtonRow(outputEntry, tooltip, payload)
+!mmm     set entryCount = entryCount + 1
 !mmm   end for
+!mmm
+!mmm   if entryCount == 0
+!mmm     set output = output & chatTightBoxRow("(keine Einträge)")
+!mmm   end if 
+!mmm
 !mmm   do chat(output)
 !mmm
 !mmm end function

--- a/examples/midgard/libMidgardGlobal/libExchange.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchange.mmm
@@ -6,7 +6,7 @@
 !rem //
 !mmm function _libExchange()
 !mmm   
-!mmm   set libVersion = "libExchange v1.0-pre (2025-04-16)"
+!mmm   set libVersion = "libExchange v1.0-pre2 (2025-04-19)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Define character sheet to use as central storage (for now, this happens already in _libMidgard)
@@ -44,7 +44,7 @@
 !mmm function m3mgdExchangeFlushRegistry(registryID)
 !mmm
 !mmm   if isdenied(m3mgdExchange.(registryID))
-!mmm     debug chat: m3mgdExchangeFlushRegistry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     chat: m3mgdExchangeFlushRegistry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   end if
 !mmm
@@ -69,10 +69,10 @@
 !mmm function m3mgdExchangeStoreEntry(registryID, entry)
 !mmm
 !mmm   if isdenied(m3mgdExchange.(registryID))
-!mmm     debug chat: m3mgdExchangeStoreEntry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     chat: m3mgdExchangeStoreEntry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   else if isunknown(entry.origin.character_id) or isdenied(entry.origin.character_id)
-!mmm     debug chat: m3mgdExchangeStoreEntry(): cannot store data with unknown or denied reference for **origin** token/character: ${entry.origin} Aborting.
+!mmm     chat: m3mgdExchangeStoreEntry(): cannot store data with unknown or denied reference for **origin** token/character: ${entry.origin} Aborting.
 !mmm     return false
 !mmm   else if not m3mgdExchange.(registryID)
 !mmm     set registry = entry
@@ -93,7 +93,7 @@
 !mmm function m3mgdExchangeGetData(registryID, searchCriteria)
 !mmm
 !mmm   if isdenied(m3mgdExchange.(registryID))
-!mmm     debug chat: m3mgdExchangeGetData(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     chat: m3mgdExchangeGetData(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   end if
 !mmm
@@ -128,10 +128,10 @@
 !mmm function m3mgdExchangeDelete(registryID, searchCriteria)
 !mmm
 !mmm   if isdenied(m3mgdExchange.(registryID))
-!mmm     debug chat: m3mgdExchangeDeleteEntry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     chat: m3mgdExchangeDeleteEntry(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   else if not m3mgdExchange.(registryID)
-!mmm     debug chat: m3mgdExchangeDeleteEntry(): data exchange registry ${registryID} empty/non-existant => nothing to delete. Aborting.
+!mmm     chat: m3mgdExchangeDeleteEntry(): data exchange registry ${registryID} empty/non-existant => nothing to delete. Aborting.
 !mmm     return false
 !mmm   end if
 !mmm
@@ -153,7 +153,6 @@
 !mmm     end if
 !mmm   end for
 !mmm
-!mmm   debug chat: deleting ${foundEntries}
 !mmm   set serialRegistry = serialize(survivingEntries)
 !mmm   return (setattr(m3mgdExchange, registryID, serialRegistry) eq serialRegistry)
 !mmm
@@ -166,10 +165,10 @@
 !mmm function m3mgdExchangeEdit(registryID, searchCriteria, newData)
 !mmm
 !mmm   if isdenied(m3mgdExchange.(registryID))
-!mmm     debug chat: m3mgdExchangeEdit(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     chat: m3mgdExchangeEdit(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   else if not m3mgdExchange.(registryID)
-!mmm     debug chat: m3mgdExchangeEdit(): data exchange registry ${registryID} empty/non-existant => nothing to edit. Aborting.
+!mmm     chat: m3mgdExchangeEdit(): data exchange registry ${registryID} empty/non-existant => nothing to edit. Aborting.
 !mmm     return false
 !mmm   end if
 !mmm
@@ -196,14 +195,12 @@
 !mmm   if match
 !mmm     set serialRegistry = serialize(newRegistry)
 !mmm     if setattr(m3mgdExchange, registryID, serialRegistry) eq serialRegistry
-!mmm       debug chat: Changes saved: ${modifiedEntries}
 !mmm       return modifiedEntries
 !mmm     else
-!mmm       debug chat: Unable to save changes: ${modifiedEntries}
 !mmm       return false
 !mmm     end if
 !mmm   else
-!mmm     debug chat: No match, no change for criteria ${searchCriteria} with new data ${newData}.
+!rem  //   debug chat: No match, no change for criteria ${searchCriteria} with new data ${newData}.
 !mmm     return false
 !mmm   end if
 !mmm
@@ -216,7 +213,7 @@
 !mmm function m3mgdExchangeRegEdit(registryID, searchCriteria)
 !mmm
 !mmm   if isdenied(m3mgdExchange.(registryID))
-!mmm     debug chat: m3mgdExchangeRegEdit(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     chat: m3mgdExchangeRegEdit(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
 !mmm     return false
 !mmm   end if
 !mmm

--- a/examples/midgard/libMidgardGlobal/libExchange.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchange.mmm
@@ -9,13 +9,22 @@
 !mmm   set libVersion = "libExchange v1.0 (2025-04-21)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
-!rem   // Define character sheet to use as central storage (for now, this happens already in _libMidgard)
+!rem   // Define character sheet to use as central storage
+!mmm   set m3mgdExchangeDataSheet = "MacroSheet"
+!mmm   set m3mgdExchange = m3mgdExchangeDataSheet.character_id
+!mmm   if m3mgdExchange.permission ne "view" and m3mgdExchange.permission ne "control" 
+!mmm     do whisperback(libVersion & " - No permission to access Midgard data exchange sheet '" & m3mgdExchangeDataSheet & "'. Data exchange will not work.")
+!mmm     do delay(5)
+!mmm     return false
+!mmm   end if
+!mmm
+!rem   // Set up individual registry attributes
 !mmm   set m3mgdExchangeRegistries = { combatData: "m3mgdCombatData", activePersistentEffects: "m3mgdActivePersistentEffects" }
 !mmm   for dataRegistry in m3mgdExchangeRegistries...
-!mmm     if dataRegistry.value.permission ne "view" and dataRegistry.value.permission ne "control" 
-!mmm       do whisperback(libVersion & " - No permission to access Midgard data exchange sheet '" & m3mgdExchangeDataSheet & "'. Data exchange will not work.")
+!mmm     if isunknown(m3mgdExchange.(dataRegistry.value)) or m3mgdExchange.(dataRegistry.value) eq ""
+!mmm       do setattr(m3mgdExchange, dataRegistry.value, serialize({}))
+!mmm       do whisperback(libVersion & " - No registry '" & dataRegistry.value & "' in sheet '" & m3mgdExchange & "', created a new one.")
 !mmm       do delay(5)
-!mmm       return false
 !mmm     end if
 !mmm   end for
 !mmm
@@ -25,7 +34,7 @@
 !rem   // Publish game-global variables defined below
 !rem
 !rem   //publish to game: m3mgdExchangeDataSheet, m3mgdExchange
-!mmm   publish to game: m3mgdExchangeRegistries
+!mmm   publish to game: m3mgdExchange, m3mgdExchangeDataSheet, m3mgdExchangeRegistries
 !rem
 !rem   // Publish game-global functions defined below
 !rem

--- a/examples/midgard/libMidgardGlobal/libExchangeTest.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchangeTest.mmm
@@ -39,7 +39,7 @@
 !mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "combatAttack", type: "magic", rollResult: 21 }  )
 !mmm   
 !mmm   debug chat: Deleting a single entry
-!mmm   debug do m3mgdExchangeDeleteEntry(script.dataExchangeID, { origin: "Yerrick MacRothgar".token_id } )
+!mmm   debug do m3mgdExchangeDelete(script.dataExchangeID, { origin: "Yerrick MacRothgar".token_id } )
 !mmm   
 !mmm   debug chat: Retrieving the entire registry ... 
 !mmm   combine chat
@@ -54,50 +54,7 @@
 !mmm   
 !rem // === rewritten libMidgard functions ===================================================================================================================
 !rem //
-!rem
-!rem // m3mgdExchangeStoreAttack(attackData)
-!rem //
-!mmm function m3mgdExchangeStoreAttack(attackData)
-!mmm   
-!mmm   set dataExchangeID = script.dataExchangeID
-!mmm
-!rem   // Check for another active attack by the same origin against the same target, which would need to be deleted first to avoid confusion
-!mmm   set activeAttacks = m3mgdExchangeGetData(dataExchangeID, { origin: attackData.origin, target: attackData.target })
-!mmm   if ? activeAttacks
-!mmm     debug chat: While storing attack data for other scripts, found unresolved attack(s) by the same origin against the same target. Delete manually and retry. ${activeAttacks}
-!mmm   end if 
-!rem 
-!rem   // Store attackData
-!mmm   return m3mgdExchangeStoreEntry(dataExchangeID, attackData)
-!mmm   
-!mmm end function
-!mmm
-!mmm function m3mgdExchangeRegEdit(registryID, searchCriteria)
-!mmm
-!mmm   if isdenied(m3mgdExchange.(registryID))
-!mmm     debug chat: m3mgdExchangeRegEdit(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
-!mmm     return false
-!mmm   end if
-!mmm
-!mmm   set output = chat(chatTightBoxHeader("m3mgdExchangeRegEdit"))
-!mmm   for entry in m3mgdExchangeGetData(registryID, searchCriteria)
-!mmm     set outputEntry = ""
-!mmm     set tooltip = ""
-!mmm     for propertyPair in entry...
-!mmm       if isunknown(propertyPair.value.token_id) or isdenied(propertyPair.value.token_id)
-!mmm         set outputEntry = outputEntry & " | " & propertyPair.key & ": " & propertyPair.value
-!mmm       else
-!mmm         set outputEntry = outputEntry & " | " & propertyPair.key & ": " & propertyPair.value.token_name
-!mmm         set tooltip = propertyPair.value
-!mmm       end if
-!mmm     end for
-!mmm     set payload = literal("!mmm customize") & "&#13;"
-!mmm     set payload = payload & literal("!mmm do chat('called to do sth')") & "&#13;"
-!mmm     set payload = payload & literal("!mmm end customize") & "&#13;" & m3mgdScriptCommands.exchangeRegEdit & "&#13;"
-!mmm     set output = output & chatTightBoxButtonRow(outputEntry, tooltip, payload)
-!mmm   end for
-!mmm   do chat(output)
-!mmm end function
+!rem // moved to libExchange
 !rem //
 !rem // === TEST routine =====================================================================================================================================
 !mmm function combatDataTest()  
@@ -107,7 +64,7 @@
 !mmm   do m3mgdExchangeStoreAttack(testAttackData)
 !mmm   set testAttackData = { origin: "Titos Panathos".token_id, target: "-OCOtXCg3YoWVEwO1dKI", action: "combatAttack", attackType: "magic", magicSpell: "Frostball", attackResult: 34, criticalAttack: false, damageResult: 7, damageRoll: 5 }
 !rem   // mundane attacks require additionally weaponType with up to two values!
-!mmm   do m3mgdExchangeStoreAttack(testAttackData)
+!mmm   do m3mgdExchangeStoreAttack(testAttackData) 
 !mmm   
 !mmm   set testAttackData = { origin: "Yorric MacRathgar".token_id, target: "-OCOtXCg3YoWVEwO1dKI", action: "combatAttack", attackType: "magic", magicSpell: "Feuerlanze", attackResult: 25, criticalAttack: false, damageResult: 9, damageRoll: 9 }
 !mmm   do m3mgdExchangeStoreAttack(testAttackData)

--- a/examples/midgard/libMidgardGlobal/libExchangeTest.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchangeTest.mmm
@@ -1,7 +1,8 @@
 !rem // libExchangeTest
 !rem //
 !mmm script
-!mmm   
+!mmm   set m3mgdScriptCommands = { m3mgdScriptCommands, exchangeRegEdit: "&#x25;{MacroSheet|exchangeRegEdit}" }
+!mmm
 %{MacroSheetLibrary|libExchange}
 !mmm   do _libExchange()
 !mmm   
@@ -11,31 +12,31 @@
 !mmm
 !mmm function basicTests()   
 !mmm   debug chat: Storing a single data entry ...
-!mmm   debug do m3mgdExchangeStoreEntry(script.dataExchangeID, { origin: "Yorric MacRathgar".token_id, action: "attack", target: "someone, not quite sure who", type: "magic", rollResult: 27 } )
+!mmm   debug do m3mgdExchangeStoreEntry(script.dataExchangeID, { origin: "Yorric MacRathgar".token_id, action: "combatAttack", target: "someone, not quite sure who", type: "magic", rollResult: 27 } )
 !mmm   
 !mmm   debug chat: Storing a second data entry ...
-!mmm   debug do m3mgdExchangeStoreEntry(script.dataExchangeID, { origin: "Yerrick MacRothgar".token_id, action: "attack", target: "Sad Orc 1", type: "melee", rollResult: 21 } )
+!mmm   debug do m3mgdExchangeStoreEntry(script.dataExchangeID, { origin: "Yerrick MacRothgar".token_id, action: "combatAttack", target: "Titos Panathos", type: "melee", rollResult: 21 } )
 !mmm   
 !mmm   debug chat: Retrieving the entire registry ... 
 !mmm   debug do m3mgdExchangeGetRegistry(script.dataExchangeID)
 !mmm   
-!mmm   debug chat: Retrieving a single entry using a single search criterion ... 
+!mmm   debug chat: Retrieving a single entry using a single search criterion that does not exist ... 
 !mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { origin: "Yorric MacRathgar".token_id }  )
 !mmm   
-!mmm   debug chat: Retrieving all "attack" entries using a single search criterion ... 
-!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "attack" }  )
+!mmm   debug chat: Retrieving all "combatAttack" entries using a single search criterion ... 
+!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "combatAttack" }  )
 !mmm   
 !mmm   debug chat: Storing a third data entry ...
-!mmm   debug do m3mgdExchangeStoreEntry(script.dataExchangeID, { origin: "Titos Panathos".token_id, action: "attack", target: "Sad Orc 2", type: "magic", rollResult: 39 } )
+!mmm   debug do m3mgdExchangeStoreEntry(script.dataExchangeID, { origin: "Titos Panathos".token_id, action: "combatAttack", target: "Yerrick MacRothgar".token_id, type: "magic", rollResult: 39 } )
 !mmm   
 !mmm   debug chat: Failing to retrieving anything using the wrong search criterion ... 
 !mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { origin: sender }  )
 !mmm   
 !mmm   debug chat: Retrieving all magical attack entries using two search criteria ... 
-!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "attack", type: "magic" }  )
+!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "combatAttack", type: "magic" }  )
 !mmm   
 !mmm   debug chat: Testing last-criterion-counts, should yield no results ... 
-!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "attack", type: "magic", rollResult: 21 }  )
+!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "combatAttack", type: "magic", rollResult: 21 }  )
 !mmm   
 !mmm   debug chat: Deleting a single entry
 !mmm   debug do m3mgdExchangeDeleteEntry(script.dataExchangeID, { origin: "Yerrick MacRothgar".token_id } )
@@ -71,17 +72,49 @@
 !mmm   
 !mmm end function
 !mmm
+!mmm function m3mgdExchangeRegEdit(registryID, searchCriteria)
+!mmm
+!mmm   if isdenied(m3mgdExchange.(registryID))
+!mmm     debug chat: m3mgdExchangeRegEdit(): attribute m3mgdExchange.${registryID} not accessible. Aborting.
+!mmm     return false
+!mmm   end if
+!mmm
+!mmm   set output = chat(chatTightBoxHeader("m3mgdExchangeRegEdit"))
+!mmm   for entry in m3mgdExchangeGetData(registryID, searchCriteria)
+!mmm     set outputEntry = ""
+!mmm     set tooltip = ""
+!mmm     for propertyPair in entry...
+!mmm       if isunknown(propertyPair.value.token_id) or isdenied(propertyPair.value.token_id)
+!mmm         set outputEntry = outputEntry & " | " & propertyPair.key & ": " & propertyPair.value
+!mmm       else
+!mmm         set outputEntry = outputEntry & " | " & propertyPair.key & ": " & propertyPair.value.token_name
+!mmm         set tooltip = propertyPair.value
+!mmm       end if
+!mmm     end for
+!mmm     set payload = literal("!mmm customize") & "&#13;"
+!mmm     set payload = payload & literal("!mmm do chat('called to do sth')") & "&#13;"
+!mmm     set payload = payload & literal("!mmm end customize") & "&#13;" & m3mgdScriptCommands.exchangeRegEdit & "&#13;"
+!mmm     set output = output & chatTightBoxButtonRow(outputEntry, tooltip, payload)
+!mmm   end for
+!mmm   do chat(output)
+!mmm end function
 !rem //
 !rem // === TEST routine =====================================================================================================================================
 !mmm function combatDataTest()  
 !mmm   
 !mmm   
-!mmm   set testAttackData = { origin: "Yorrick MacRathgar".token_id, target: "-OCOtXCg3YoWVEwO1dKI", attackType: "magic", magicSpell: "", attackResult: 34, criticalAttack: false, damageResult: 7, damageRoll: 5 }
+!mmm   set testAttackData = { origin: "Yorric MacRathgar".token_id, target: "-OCOtXCg3YoWVEwO1dKI", action: "combatAttack", attackType: "magic", magicSpell: "Frostball", attackResult: 34, criticalAttack: false, damageResult: 7, damageRoll: 5 }
+!mmm   do m3mgdExchangeStoreAttack(testAttackData)
+!mmm   set testAttackData = { origin: "Titos Panathos".token_id, target: "-OCOtXCg3YoWVEwO1dKI", action: "combatAttack", attackType: "magic", magicSpell: "Frostball", attackResult: 34, criticalAttack: false, damageResult: 7, damageRoll: 5 }
 !rem   // mundane attacks require additionally weaponType with up to two values!
 !mmm   do m3mgdExchangeStoreAttack(testAttackData)
 !mmm   
+!mmm   set testAttackData = { origin: "Yorric MacRathgar".token_id, target: "-OCOtXCg3YoWVEwO1dKI", action: "combatAttack", attackType: "magic", magicSpell: "Feuerlanze", attackResult: 25, criticalAttack: false, damageResult: 9, damageRoll: 9 }
+!mmm   do m3mgdExchangeStoreAttack(testAttackData)
+!mmm   set testAttackData = { origin: "Titos Panathos".token_id, target: "-OCOtXCg3YoWVEwO1dKI", action: "combatAttack", attackType: "magic", magicSpell: "Feuerlanze", attackResult: 25, criticalAttack: false, damageResult: 9, damageRoll: 9 }
+!mmm   do m3mgdExchangeStoreAttack(testAttackData)
 !mmm   
-!mmm   
+!rem   do m3mgdExchangeRegEdit(dataExchangeID)
 !mmm   
 !mmm   
 !mmm   
@@ -106,7 +139,7 @@
 !mmm end function  
 !mmm   
 !mmm   
-!rem //  do basicTests()
+!mmm   do basicTests()
 !mmm   do combatDataTest()
 !mmm   
 !mmm   

--- a/examples/midgard/libMidgardGlobal/libExchangeTest.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchangeTest.mmm
@@ -6,46 +6,74 @@
 !mmm   do _libExchange()
 !mmm   
 !mmm   debug chat: libExchange loaded and initialized.
-!mmm   
+!mmm
+!mmm   set dataExchangeID = "m3mgdTestCombatExchange"
+!mmm
+!mmm function basicTests()   
 !mmm   debug chat: Storing a single data entry ...
-!mmm   debug do m3mgdExchangeStoreEntry("m3mgdTestCombatExchange", { origin: sender.token_id, action: "attack", target: "someone, not quite sure who", type: "magic", rollResult: 27 } )
+!mmm   debug do m3mgdExchangeStoreEntry(script.dataExchangeID, { origin: "Yorric MacRathgar".token_id, action: "attack", target: "someone, not quite sure who", type: "magic", rollResult: 27 } )
 !mmm   
 !mmm   debug chat: Storing a second data entry ...
-!mmm   debug do m3mgdExchangeStoreEntry("m3mgdTestCombatExchange", { origin: "Yerrick MacRothgar".token_id, action: "attack", target: "Sad Orc 1", type: "melee", rollResult: 21 } )
+!mmm   debug do m3mgdExchangeStoreEntry(script.dataExchangeID, { origin: "Yerrick MacRothgar".token_id, action: "attack", target: "Sad Orc 1", type: "melee", rollResult: 21 } )
 !mmm   
 !mmm   debug chat: Retrieving the entire registry ... 
-!mmm   debug do m3mgdExchangeGetRegistry("m3mgdTestCombatExchange")
+!mmm   debug do m3mgdExchangeGetRegistry(script.dataExchangeID)
 !mmm   
 !mmm   debug chat: Retrieving a single entry using a single search criterion ... 
-!mmm   debug do m3mgdExchangeGetData("m3mgdTestCombatExchange", { origin: sender.token_id }  )
+!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { origin: "Yorric MacRathgar".token_id }  )
 !mmm   
 !mmm   debug chat: Retrieving all "attack" entries using a single search criterion ... 
-!mmm   debug do m3mgdExchangeGetData("m3mgdTestCombatExchange", { action: "attack" }  )
+!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "attack" }  )
 !mmm   
 !mmm   debug chat: Storing a third data entry ...
-!mmm   debug do m3mgdExchangeStoreEntry("m3mgdTestCombatExchange", { origin: "Titos Panathos".token_id, action: "attack", target: "Sad Orc 2", type: "magic", rollResult: 39 } )
+!mmm   debug do m3mgdExchangeStoreEntry(script.dataExchangeID, { origin: "Titos Panathos".token_id, action: "attack", target: "Sad Orc 2", type: "magic", rollResult: 39 } )
 !mmm   
 !mmm   debug chat: Failing to retrieving anything using the wrong search criterion ... 
-!mmm   debug do m3mgdExchangeGetData("m3mgdTestCombatExchange", { origin: sender }  )
+!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { origin: sender }  )
 !mmm   
 !mmm   debug chat: Retrieving all magical attack entries using two search criteria ... 
-!mmm   debug do m3mgdExchangeGetData("m3mgdTestCombatExchange", { action: "attack", type: "magic" }  )
+!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "attack", type: "magic" }  )
 !mmm   
 !mmm   debug chat: Testing last-criterion-counts, should yield no results ... 
-!mmm   debug do m3mgdExchangeGetData("m3mgdTestCombatExchange", { action: "attack", type: "magic", rollResult: 21 }  )
+!mmm   debug do m3mgdExchangeGetData(script.dataExchangeID, { action: "attack", type: "magic", rollResult: 21 }  )
 !mmm   
 !mmm   debug chat: Deleting a single entry
-!mmm   debug do m3mgdExchangeDeleteEntry("m3mgdTestCombatExchange", { origin: "Yerrick MacRothgar".token_id } )
+!mmm   debug do m3mgdExchangeDeleteEntry(script.dataExchangeID, { origin: "Yerrick MacRothgar".token_id } )
 !mmm   
 !mmm   debug chat: Retrieving the entire registry ... 
 !mmm   combine chat
-!mmm     for entry in m3mgdExchangeGetRegistry("m3mgdTestCombatExchange")
+!mmm     for entry in m3mgdExchangeGetRegistry(script.dataExchangeID)
 !mmm       do chat(chatTightBoxRow(entry))
 !mmm     end for
 !mmm   end combine
 !mmm 
 !mmm   debug chat: Flushing the registry ... 
-!mmm   debug do m3mgdExchangeFlushRegistry("m3mgdTestCombatExchange")
+!mmm   debug do m3mgdExchangeFlushRegistry(script.dataExchangeID)
+!mmm end function  
+!mmm   
+!rem // === rewritten libMidgard functions ===================================================================================================================
+!rem //
+!rem
+!rem // m3mgdExchangeStoreAttack(attackData)
+!rem //
+!mmm function m3mgdExchangeStoreAttack(attackData)
+!mmm   
+!mmm   set dataExchangeID = script.dataExchangeID
+!mmm
+!rem   // Check for another active attack by the same origin against the same target, which would need to be deleted first to avoid confusion
+!mmm   set activeAttacks = m3mgdExchangeGetData(dataExchangeID, { origin: attackData.origin, target: attackData.target })
+!mmm   if ? activeAttacks
+!mmm     debug chat: While storing attack data for other scripts, found unresolved attack(s) by the same origin against the same target. Delete manually and retry. ${activeAttacks}
+!mmm   end if 
+!rem 
+!rem   // Store attackData
+!mmm   return m3mgdExchangeStoreEntry(dataExchangeID, attackData)
+!mmm   
+!mmm end function
+!mmm
+!rem //
+!rem // === TEST routine =====================================================================================================================================
+!mmm function combatDataTest()  
 !mmm   
 !mmm   
 !mmm   
@@ -74,13 +102,10 @@
 !mmm   
 !mmm   
 !mmm   
+!mmm end function  
 !mmm   
 !mmm   
-!mmm   
-!mmm   
-!mmm   
-!mmm   
-!mmm   
+!mmm   do basicTests()
 !mmm   
 !mmm   
 !mmm   

--- a/examples/midgard/libMidgardGlobal/libExchangeTest.mmm
+++ b/examples/midgard/libMidgardGlobal/libExchangeTest.mmm
@@ -76,8 +76,9 @@
 !mmm function combatDataTest()  
 !mmm   
 !mmm   
-!mmm   
-!mmm   
+!mmm   set testAttackData = { origin: "Yorrick MacRathgar".token_id, target: "-OCOtXCg3YoWVEwO1dKI", attackType: "magic", magicSpell: "", attackResult: 34, criticalAttack: false, damageResult: 7, damageRoll: 5 }
+!rem   // mundane attacks require additionally weaponType with up to two values!
+!mmm   do m3mgdExchangeStoreAttack(testAttackData)
 !mmm   
 !mmm   
 !mmm   
@@ -105,7 +106,8 @@
 !mmm end function  
 !mmm   
 !mmm   
-!mmm   do basicTests()
+!rem //  do basicTests()
+!mmm   do combatDataTest()
 !mmm   
 !mmm   
 !mmm   

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -18,14 +18,6 @@
 !mmm   set m3mgdScriptCommands = { "magicAttack": "&#x25;{MacroSheet|magicAttack}", "defense": "&#x25;{MacroSheet|defense}", "resistance": "&#x25;{MacroSheet|defense}", "melee": "&#x25;{MacroSheet|meleeAttack}", "ranged": "&#x25;{MacroSheet|rangedAttack}" }
 !mmm   set m3mgdScriptCommands = { m3mgdScriptCommands, "editXP": "&#x25;{MacroSheet|editXP}", "managePersistentEffects": "&#x25;{MacroSheet|managePersistentEffects}", "defendFrostball": "&#x25;{MacroSheet|defendFrostball}", "defendSnatch": "&#x25;{MacroSheet|defendSnatch}" }
 !mmm
-!mmm   set m3mgdExchangeDataSheet = "MacroSheet"
-!mmm   set m3mgdExchange = m3mgdExchangeDataSheet.character_id
-!mmm   if m3mgdExchange.permission ne "view" and m3mgdExchange.permission ne "control" 
-!mmm     do whisperback(libVersion & " - No permission to access Midgard data exchange sheet '" & m3mgdExchangeDataSheet & "'. Data exchange will not work.")
-!mmm     do delay(5)
-!mmm     return false
-!mmm   end if
-!mmm
 !mmm   set m3mgdAttrHealthGain          = "m3mgd_health_gain"
 !mmm   set m3mgdAttrEnduranceGain       = "m3mgd_endurance_gain"
 !mmm
@@ -73,14 +65,10 @@
 !mmm     end if
 !mmm   end if
 !mmm
-!mmm   if isunknown(m3mgdExchange.m3mgdActivePersistentEffects) or m3mgdExchange.m3mgdActivePersistentEffects eq ""
-!mmm     do setattr(m3mgdExchange, "m3mgdActivePersistentEffects", serialize({}))
-!mmm   end if
-!mmm   
 !mmm   set m3mgdAttrXP = "Erfahrungsschatz"
 !mmm   set m3mgdAttrXPLog = "Erfahrungsprotokoll"
 !mmm
-!mmm   publish to game: m3mgdScriptCommands, m3mgdExchange
+!mmm   publish to game: m3mgdScriptCommands
 !mmm   publish to game: m3mgdAttrHealthGain, m3mgdAttrEnduranceGain, m3mgdExchangeAttrList
 !mmm   publish to game: m3mgdValidAttackWeaponTypes, m3mgdValidMeleeAttackWeaponTypes, m3mgdValidRangedAttackWeaponTypes
 !mmm   publish to game: m3mgdArmorPiercingWeaponTypes

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgard()
 !mmm   
-!mmm   set libVersion = "libMidgard v1.6.0-WIP6 (2025-04-16)"
+!mmm   set libVersion = "libMidgard v1.6.0-WIP7 (2025-04-16)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
@@ -15,7 +15,8 @@
 !mmm
 !rem   // Game-global constants for publication
 !rem
-!mmm   set m3mgdScriptCommands = { "magicAttack": "&#x25;{MacroSheet|magicAttack}", "defense": "&#x25;{MacroSheet|defense}", "resistance": "&#x25;{MacroSheet|defense}", "melee": "&#x25;{MacroSheet|meleeAttack}", "ranged": "&#x25;{MacroSheet|rangedAttack}", "editXP": "&#x25;{MacroSheet|editXP}", "managePersistentEffects": "&#x25;{MacroSheet|managePersistentEffects}" }
+!mmm   set m3mgdScriptCommands = { "magicAttack": "&#x25;{MacroSheet|magicAttack}", "defense": "&#x25;{MacroSheet|defense}", "resistance": "&#x25;{MacroSheet|defense}", "melee": "&#x25;{MacroSheet|meleeAttack}", "ranged": "&#x25;{MacroSheet|rangedAttack}" }
+!mmm   set m3mgdScriptCommands = { m3mgdScriptCommands, "editXP": "&#x25;{MacroSheet|editXP}", "managePersistentEffects": "&#x25;{MacroSheet|managePersistentEffects}", "defendFrostball": "&#x25;{MacroSheet|defendFrostball}", "defendSnatch": "&#x25;{MacroSheet|defendSnatch}" }
 !mmm   set m3mgdExchangeDataSheet = "MacroSheet"
 !mmm   set m3mgdExchange = m3mgdExchangeDataSheet.character_id
 !mmm 

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgard()
 !mmm   
-!mmm   set libVersion = "libMidgard v1.5.0-pre (2025-03-12)"
+!mmm   set libVersion = "libMidgard v1.6.0-WIP6 (2025-04-16)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
@@ -100,7 +100,7 @@
 !rem
 !mmm   publish to game: m3mgdValidateOwnTokenID, m3mgdValidateTokenAttribute
 !mmm   publish to game: m3mgdGetEnduranceAttribute, m3mgdGetHealthAttribute
-!mmm   publish to game: m3mgdValidateAttackData, _m3mgdExecuteCode, m3mgdRollChanceEffect, m3mgdFlushExchange
+!mmm   publish to game: m3mgdStoreAttack, m3mgdRetrieveAttack, _m3mgdExecuteCode, m3mgdRollChanceEffect, m3mgdFlushExchange
 !mmm   publish to game: _m3mgdHandleStoredAttr, m3mgdSetAttrCeiling, m3mgdAttrCeiling, m3mgdReleaseAttrCeiling
 !mmm   publish to game: m3mgdHasActivePersistentEffects, m3mgdGetActivePersistentEffects, m3mgdRemovePersistentEffect
 !mmm   publish to game: m3mgdRemovePersistentEffectPayload, m3mgdShowPersistentEffectsPayload
@@ -109,7 +109,7 @@
 !mmm   publish to game: m3mgdHealthStatusLabel, m3mgdHealthStatusEffectsDesc
 !mmm   publish to game: m3mgdModifyEndurance, m3mgdModifyHealth, m3mgdProcessInjury
 !mmm   publish to game: m3mgdGetTokenDirection, m3mgdGetViewAngle, m3mgdGetDistance, m3mgdMoveToken, m3mgdSpawnWeaponToken, m3mgdSpawnSpellToken
-!mmm   publish to game: m3mgdExchangeStoreAttack, m3mgdExchangeStoreHealthBoost, m3mgdExchangeStoreEnduranceBoost
+!mmm   publish to game: m3mgdExchangeStoreHealthBoost, m3mgdExchangeStoreEnduranceBoost
 !mmm   publish to game: m3mgdSpellList, m3mgdListDefenseWeapons, m3mgdListMeleeAttackWeapons, m3mgdListRangedAttackWeapons
 !mmm   publish to game: m3mgdDefenseWeaponType, m3mgdMeleeWeaponType, m3mgdRangedWeaponProperties
 !mmm   publish to game: _m3mgdSpellButtonPayload, _m3mgdWeaponButtonPayload, m3mgdSpellSelectorChatMenu, m3mgdWeaponSelectorChatMenu, m3mgdRerunButton
@@ -197,63 +197,89 @@
 !mmm     return m3mgdValidateTokenAttribute(tokenID, "bar3")
 !mmm   end if
 !mmm end function
+!rem 
+!rem // m3mgdStoreAttack(attackData)
+!rem //
+!rem //   Stores attackData in central data registry if there is no other set of attackData by the same origin against the same target.
+!rem //
+!mmm function m3mgdStoreAttack(attackData)
+!mmm   
+!rem   // Check for another active attack by the same origin against the same target
+!mmm   set filter = { action: "combatAttack", origin: attackData.origin, target: attackData.target }
+!mmm   set activeAttacks = m3mgdExchangeGetData(m3mgdExchangeRegistries.combatData, filter)
+!mmm   if activeAttacks
+!mmm     debug chat: Overwriting previous attack data for the same origin against the same target (${activeAttacks}).
+!mmm     debug do m3mgdExchangeDelete(m3mgdExchangeRegistries.combatData, filter)
+!mmm   end if 
+!rem 
+!rem   // Store attackData
+!mmm   return m3mgdExchangeStoreEntry(m3mgdExchangeRegistries.combatData, attackData)
+!mmm   
+!mmm end function
 !rem
-!rem // m3mgdValidateAttackData([dataExchangeID])
+!rem // m3mgdRetrieveAttack(targetID, [originID], [dataExchangeID])
 !rem // 
-!rem //   Expects a global data exchange character sheet as m3mgdExchange or as an argument.
-!rem //   Validates attack data stack within that sheet and returns true/false.
+!rem //   Pulls stored attack data for the token pair targetID/[originID] from the registry [dataExchangeID].
+!rem //   Validates attack data stack and returns it if valid, otherwise returns false.
 !rem // 
-!mmm function m3mgdValidateAttackData(dataExchangeID)
+!mmm function m3mgdRetrieveAttack(targetID, originID, dataExchangeID)
 !mmm
+!mmm   if isdefault(targetID) or isunknown(targetID.token_id)
+!mmm     do whisperback("m3mgdRetrieveAttack(): No target ID given, aborting.")
+!mmm     return false
+!mmm   end if
 !mmm   if isdefault(dataExchangeID)
-!mmm     set dataExchangeID = m3mgdExchange
+!mmm     set dataExchangeID = m3mgdExchangeRegistries.combatData
 !mmm   end if
 !mmm   if isunknown(dataExchangeID) or isdenied(dataExchangeID)
-!mmm     do whisperback("Invalid attack data exchange sheet: " & getreason(dataExchangeID))
+!mmm     do whisperback("m3mgdRetrieveAttack(): Invalid attack data exchange sheet: " & getreason(dataExchangeID))
 !mmm     return false
 !mmm   end if
 !mmm
+!mmm   set searchCriteria = { action: "combatAttack", target: targetID }
+!mmm   if not isdefault(originID)
+!mmm     set searchCriteria = { searchCriteria, origin: originID }
+!mmm   end if 
+!mmm   set attackData = m3mgdExchangeGetData(dataExchangeID, searchCriteria)
+!mmm
 !mmm   set validItems = 0
-!mmm   if dataExchangeID.(m3mgdAttrAttackTargetID).token_id
+!mmm   if attackData.origin.token_id
 !mmm     set validItems = validItems + 1
 !mmm   end if
-!mmm   if dataExchangeID.(m3mgdAttrAttackType) eq "melee" or dataExchangeID.(m3mgdAttrAttackType) eq "ranged" or dataExchangeID.(m3mgdAttrAttackType) eq "magic"
+!mmm   if attackData.attackType eq "melee" or attackData.attackType eq "ranged" or attackData.attackType eq "magic"
 !mmm     set validItems = validItems + 1
 !mmm   end if
-!mmm   if dataExchangeID.(m3mgdAttrAttackResult) >= 20
+!mmm   if attackData.attackResult >= 20
 !mmm     set validItems = validItems + 1
 !mmm   end if
-!mmm   if dataExchangeID.(m3mgdAttrAttackResult).max eq "true" or dataExchangeID.(m3mgdAttrAttackResult).max eq "false"
+!mmm   if not isunknown(attackData.attackDamage) and attackData.attackDamage >= 0
 !mmm     set validItems = validItems + 1
 !mmm   end if
-!mmm   if not isunknown(dataExchangeID.(m3mgdAttrAttackDamage)) and dataExchangeID.(m3mgdAttrAttackDamage) >= 0
+!mmm   if not attackData.attackType eq "magic" and (not isunknown(attackData.attackDamageRoll) and attackData.attackDamageRoll >= 0)
 !mmm     set validItems = validItems + 1
 !mmm   end if
-!mmm   if not dataExchangeID.(m3mgdAttrAttackType) eq "magic" and (not isunknown(dataExchangeID.(m3mgdAttrAttackDamageRoll)) and dataExchangeID.(m3mgdAttrAttackDamageRoll) >= 0)
-!mmm     set validItems = validItems + 1
-!mmm   end if
-!mmm   if not isunknown(dataExchangeID.(m3mgdAttrAttackWeaponType))
-!mmm     if dataExchangeID.(m3mgdAttrAttackWeaponType).max ne "" 
+!mmm   if not isunknown(attackData.weaponType)
+!mmm     if attackData.weaponType[1] ne "" 
 !mmm       set validItems = validItems + 1
-!mmm     else if dataExchangeID.(m3mgdAttrAttackType) eq "melee" 
-!mmm       if m3mgdValidMeleeAttackWeaponTypes where ... eq dataExchangeID.(m3mgdAttrAttackWeaponType)
+!mmm     else if attackData.attackType eq "melee" 
+!mmm       if m3mgdValidMeleeAttackWeaponTypes where ... eq attackData.weaponType
 !mmm         set validItems = validItems + 1
 !mmm       else
-!mmm         do whisperback("Invalid melee attack weapon type: " & dataExchangeID.(m3mgdAttrAttackWeaponType) & " is none of " & m3mgdValidMeleeAttackWeaponTypes)
+!mmm         do whisperback("Invalid melee attack weapon type: " & attackData.weaponType & " is none of " & m3mgdValidMeleeAttackWeaponTypes)
 !mmm       end if
-!mmm     else if dataExchangeID.(m3mgdAttrAttackType) eq "ranged" 
-!mmm       if m3mgdValidRangedAttackWeaponTypes where ... eq dataExchangeID.(m3mgdAttrAttackWeaponType)
+!mmm     else if attackData.attackType eq "ranged" 
+!mmm       if m3mgdValidRangedAttackWeaponTypes where ... eq attackData.weaponType
 !mmm         set validItems = validItems + 1
 !mmm       else
-!mmm         do whisperback("Invalid range attack weapon type: " & dataExchangeID.(m3mgdAttrAttackWeaponType) & " is none of " & m3mgdValidRangedAttackWeaponTypes)
+!mmm         do whisperback("Invalid range attack weapon type: " & attackData.weaponType & " is none of " & m3mgdValidRangedAttackWeaponTypes)
 !mmm       end if
 !mmm     end if
 !mmm   end if 
 !mmm
-!mmm   if dataExchangeID.(m3mgdAttrAttackType) eq "magic"
-!mmm     return (validItems >= 5)
+!mmm   if (attackData.attackType eq "magic" and validItems >= 4) or (attackData.attackType ne "magic" and validItems == 6)
+!mmm     return attackData
 !mmm   else 
-!mmm     return (validItems == 7)
+!mmm     return false
 !mmm   end if
 !mmm
 !mmm end function
@@ -1196,95 +1222,6 @@
 !mmm   return selected.token_id
 !mmm end function
 !rem
-!rem // m3mgdExchangeStoreAttack(attackType, [magicSpell])
-!rem //
-!mmm function m3mgdExchangeStoreAttack(attackType, magicSpell)
-!mmm   
-!mmm   set dataExchangeID = m3mgdExchange
-!mmm   do m3mgdFlushExchange(dataExchangeID)
-!mmm
-!mmm   if attackType eq "magic" and isdefault(magicSpell)
-!mmm     do whisperback("Incomplete data for a magic attack: spell argument missing")
-!mmm     return false
-!mmm   else if attackType ne "magic"
-!mmm     set magicSpell = ""
-!mmm   end if
-!mmm 
-!mmm   set storeTarget = 4
-!mmm   set storeCounter = 0
-!mmm
-!rem   // Store the bare minimum of any attack dataset
-!mmm
-!mmm   if setattr(dataExchangeID, m3mgdAttrAttackType, attackType) eq attackType
-!mmm     set storeCounter = storeCounter + 1
-!mmm   end if
-!mmm   if setattrmax(dataExchangeID, m3mgdAttrAttackType, magicSpell) eq magicSpell
-!mmm     set storeCounter = storeCounter + 1
-!mmm   end if
-!mmm   if setattr(dataExchangeID, m3mgdAttrAttackerID, script.cOwnID) eq script.cOwnID
-!mmm     set storeCounter = storeCounter + 1
-!mmm   end if
-!mmm   if setattr(dataExchangeID, m3mgdAttrAttackTargetID, script.cTargetID) eq script.cTargetID
-!mmm     set storeCounter = storeCounter + 1
-!mmm   end if
-!mmm   
-!rem   // Store additional data only if present
-!mmm
-!mmm   if script.attackResult >= 20
-!mmm     set storeTarget = storeTarget + 1
-!mmm     if setattr(dataExchangeID, m3mgdAttrAttackResult, script.attackResult) == script.attackResult
-!mmm       set storeCounter = storeCounter + 1
-!mmm     end if
-!mmm   end if
-!mmm   
-!mmm   if script.criticalAttack == true or script.criticalAttack == false
-!mmm     set storeTarget = storeTarget + 1
-!rem     // normalize boolean variable to avoid setting the attribute to undef (which would evaluate as false above)
-!mmm     set criticalAttack = (script.criticalAttack == true)
-!mmm     if setattrmax(dataExchangeID, m3mgdAttrAttackResult, criticalAttack) == script.criticalAttack
-!mmm       set storeCounter = storeCounter + 1
-!mmm     end if
-!mmm   end if
-!mmm   
-!mmm   if script.damageResult ne undef
-!mmm     set storeTarget = storeTarget + 1
-!mmm     if setattr(dataExchangeID, m3mgdAttrAttackDamage, script.damageResult) == script.damageResult
-!mmm       set storeCounter = storeCounter + 1
-!mmm     end if
-!mmm   end if
-!mmm   
-!mmm   if script.cDamageRoll ne undef
-!mmm     set storeTarget = storeTarget + 1
-!mmm     set damageRoll = zeroOrPositive(script.cDamageRoll)
-!mmm     if setattr(dataExchangeID, m3mgdAttrAttackDamageRoll, damageRoll) == damageRoll
-!mmm       set storeCounter = storeCounter + 1
-!mmm     end if
-!mmm   end if
-!mmm
-!mmm   if script.cWeaponType ne ""
-!mmm     set storeTarget = storeTarget + 1
-!mmm     if setattr(dataExchangeID, m3mgdAttrAttackWeaponType, script.cWeaponType[0]) eq script.cWeaponType[0]
-!mmm       set storeCounter = storeCounter + 1
-!mmm     end if
-!mmm     if script.cWeaponType[1] ne ""
-!mmm       set storeTarget = storeTarget + 1
-!mmm       if setattrmax(dataExchangeID, m3mgdAttrAttackWeaponType, script.cWeaponType[1]) eq script.cWeaponType[1]
-!mmm         set storeCounter = storeCounter + 1
-!mmm       end if
-!mmm     end if
-!mmm   end if
-!mmm
-!mmm   if script.magicEnduranceCost ne undef
-!mmm     set storeTarget = storeTarget + 1
-!mmm     if setattr(dataExchangeID, m3mgdAttrAttackEnduranceCost, script.magicEnduranceCost) == script.magicEnduranceCost
-!mmm       set storeCounter = storeCounter + 1
-!mmm     end if
-!mmm   end if
-!mmm
-!mmm   return (storeCounter == storeTarget)
-!mmm   
-!mmm end function
-!rem
 !rem // m3mgdExchangeStoreHealthBoost(healthGain, targetID)
 !rem //
 !rem //   Allows for positive AND negative values of healthGain, since critical failures of First Aid etc. result in damage.
@@ -1603,6 +1540,8 @@
 !mmm   else
 !mmm     set payload = payload & literal("!mmm if selected") & "&#13;"
 !mmm     set payload = payload & literal("!mmm   set cOwnID = selected.token_id") & "&#13;"
+!mmm     set payload = payload & literal("!mmm else") & "&#13;"
+!mmm     set payload = payload & literal("!mmm   set cOwnID = '" & tokenID & "'") & "&#13;"
 !mmm     set payload = payload & literal("!mmm end if") & "&#13;"
 !mmm     set payload = payload & literal("!mmm set cGMSilentMode = true") & "&#13;"
 !mmm   end if
@@ -1627,25 +1566,18 @@
 !mmm   set payload = payload & literal("!mmm set attackerID = \"@" & "{target|Wer greift an?|token_id}\"") & "&#13;"
 !mmm   set payload = payload & literal("!mmm set targetID = \"@" & "{target|Wer wird angegriffen (Ziel)?|token_id}\"") & "&#13;"
 !mmm   set payload = payload & literal("!mmm set attackResult = \"?" & "{Angriffswert|0}\"") & "&#13;"
-!mmm   set payload = payload & literal("!mmm set criticalAttack = \"?" & "{Kritischer Erfolg beim Angriff|Nein,0|Ja,1}\"") & "&#13;"
+!mmm   set payload = payload & literal("!mmm set criticalAttack = ?" & "{Kritischer Erfolg beim Angriff|Nein,false|Ja,true}") & "&#13;"
 !mmm   set payload = payload & literal("!mmm set attackDamage = \"?" & "{Schaden laut Angreifer|0}\"") & "&#13;"
 !mmm   set payload = payload & literal("!mmm set attackDamageRoll = \"?" & "{Schadenswurf (Ergebnis von 1W6+1 ohne Boni) laut Angreifer|0}\"") & "&#13;"
-!mmm   set payload = payload & literal("!mmm set armorPiercing = \"?" & "{Angriff mit Lang-/Kompositbogen oder schwerer Armbrust|Nein,0|Ja,1}\"") & "&#13;"
 !mmm   set payload = payload & literal("!mmm set weaponType = \"?" & "{Waffentyp|" & stringify(m3mgdValidAttackWeaponTypes, "", "|") & "}\"") & "&#13;"
 !mmm   set payload = payload & literal("!mmm if attackResult < 20") & "&#13;"
 !mmm   set payload = payload & literal("!mmm   do whisperback(\"Abbruch: Angriff mit **\" & attackResult & \"** war nicht erfolgreich, keine Abwehr nötig.\")") & "&#13;"
 !mmm   set payload = payload & literal("!mmm   exit script") & "&#13;"
 !mmm   set payload = payload & literal("!mmm end if") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do m3mgdFlushExchange()") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do setattr(m3mgdExchange, m3mgdAttrAttackType, attackType)") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do setattr(m3mgdExchange, m3mgdAttrAttackerID, attackerID)") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do setattr(m3mgdExchange, m3mgdAttrAttackTargetID, targetID)") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do setattr(m3mgdExchange, m3mgdAttrAttackResult, attackResult)") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do setattrmax(m3mgdExchange, m3mgdAttrAttackResult, (criticalAttack == 1))") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do setattr(m3mgdExchange, m3mgdAttrAttackDamage, attackDamage)") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do setattr(m3mgdExchange, m3mgdAttrAttackDamageRoll, attackDamageRoll)") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do setattr(m3mgdExchange, m3mgdAttrAttackArmorPiercing, armorPiercing)") & "&#13;"
-!mmm   set payload = payload & literal("!mmm do setattr(m3mgdExchange, m3mgdAttrAttackWeaponType, weaponType)") & "&#13;"
+!mmm   set payload = payload & literal("!mmm set attackData = { origin: attackerID, target: targetID, action: \"combatAttack\", attackType: attackType, attackResult: attackResult, criticalAttack: criticalAttack, damageResult: attackDamage, damageRoll: attackDamageRoll, weaponType: weaponType }") & "&#13;"
+!mmm   set payload = payload & literal("!mmm if not m3mgdStoreAttack(attackData)") & "&#13;"
+!mmm   set payload = payload & literal("!mmm   do whisperback(\"Fehlschlag: Angriffsdaten konnten nicht gespeichert werden - ${attackData}\")") & "&#13;"
+!mmm   set payload = payload & literal("!mmm end if") & "&#13;"
 !mmm   set payload = payload & "!mmm end script&#13;"
 !mmm   set payload = payload & m3mgdDefenseInitPayload(tokenID)
 !mmm   set payload = payload & m3mgdScriptCommands.defense
@@ -2656,9 +2588,9 @@
 !mmm   return " [🗘](" & payload & cssTableHeaderButton & ") "
 !mmm end function
 !rem
-!rem // m3mgdDefenseDataTable()
+!rem // m3mgdDefenseDataTable(attackData)
 !rem //
-!mmm function m3mgdDefenseDataTable()
+!mmm function m3mgdDefenseDataTable(attackData)
 !mmm
 !rem   // Prepare output
 !rem
@@ -2667,11 +2599,11 @@
 !mmm   set shapeMoji = m3mgdShapeMoji(script.cOwnID)
 !mmm
 !mmm   if script.criticalAttack
-!mmm     set attackResult = highlight(script.attackResult, "good", "Kritisch erfolgreicher Angriff von " & m3mgdExchange.(m3mgdAttrAttackerID).name)
+!mmm     set attackResult = highlight(attackData.attackResult, "good", "Kritisch erfolgreicher Angriff von " & attackData.origin.name)
 !mmm   else
-!mmm     set attackResult = highlight(script.attackResult, "info", "Angriff von " & m3mgdExchange.(m3mgdAttrAttackerID).name)
+!mmm     set attackResult = highlight(attackData.attackResult, "info", "Angriff von " & attackData.origin.name)
 !mmm   end if
-!mmm   set attackDamage = highlight(m3mgdExchange.(m3mgdAttrAttackDamage), "info", m3mgdExchange.(m3mgdAttrAttackType))
+!mmm   set attackDamage = highlight(attackData.damageResult, "info", attackData.attackType)
 !mmm   set effEnduranceLoss = highlight(script.effEnduranceLoss, "normal")
 !mmm   set effHealthLoss = highlight(script.effHealthLoss, "normal", "RS: " & script.effArmorProtection)
 !mmm
@@ -2689,8 +2621,8 @@
 !mmm
 !mmm     if script.cNoDefense
 !mmm       set heading = "Keine Abwehr (wehrlos)"
-!mmm     else if m3mgdExchange.(m3mgdAttrAttackType) eq "magic"
-!mmm       set heading = "Abwehr gegen " & m3mgdExchange.(m3mgdAttrAttackType).max
+!mmm     else if attackData.attackType eq "magic"
+!mmm       set heading = "Abwehr gegen " & attackData.magicSpell
 !mmm     else if script.cWeaponLabel eq "Abwehr ohne Schild"
 !mmm       set heading = "Abwehr ohne Schild"
 !mmm     else
@@ -2709,22 +2641,22 @@
 !mmm     end if
 !mmm
 !mmm     if script.defenseSuccess and iscritical(script.cDefenseRoll) and not script.criticalAttack
-!mmm       chat: {\{Kritischer Abwehrerfolg=${script.defenseResult} **Leichter Treffer** [🎲](${m3mgdCriticalEffectRollPayload(script.cOwnID, "defenseSuccess", m3mgdExchange.(m3mgdAttrAttackerID))}${cssTableCellButton}) }\}
+!mmm       chat: {\{Kritischer Abwehrerfolg=${script.defenseResult} **Leichter Treffer** [🎲](${m3mgdCriticalEffectRollPayload(script.cOwnID, "defenseSuccess", attackData.origin)}${cssTableCellButton}) }\}
 !mmm     else if script.defenseSuccess
 !mmm       chat: {\{Abwehrerfolg=${script.defenseResult} **Leichter Treffer**}\}
 !mmm     else if script.criticalAttack == true and isfumble(script.cDefenseRoll)
 !mmm       chat: {\{Kritischer Fehlschlag bei Abwehr eines kritischen Treffers=${script.defenseResult} **Schwerer kritischer Treffer** 
-!mmm       chat: [🎲](${m3mgdCriticalEffectRollPayload(m3mgdExchange.(m3mgdAttrAttackerID), "attackSuccess", script.cOwnID)}${cssTableCellButton})
-!mmm       chat: [🎲](${m3mgdCriticalEffectRollPayload(script.cOwnID, "defenseFailure", m3mgdExchange.(m3mgdAttrAttackerID))}${cssTableCellButton}) }\}
+!mmm       chat: [🎲](${m3mgdCriticalEffectRollPayload(attackData.origin, "attackSuccess", script.cOwnID)}${cssTableCellButton})
+!mmm       chat: [🎲](${m3mgdCriticalEffectRollPayload(script.cOwnID, "defenseFailure", attackData.origin)}${cssTableCellButton}) }\}
 !mmm     else if script.criticalAttack == true
 !mmm       chat: {\{Fehlschlag=${script.defenseResult} **Schwerer kritischer Treffer** 
-!mmm       if m3mgdExchange.(m3mgdAttrAttackType) ne "magic"
-!mmm         chat: [🎲](${m3mgdCriticalEffectRollPayload(m3mgdExchange.(m3mgdAttrAttackerID), "attackSuccess", script.cOwnID)}${cssTableCellButton}) }\}
+!mmm       if attackData.attackType ne "magic"
+!mmm         chat: [🎲](${m3mgdCriticalEffectRollPayload(m3mgdExchangeattackData.origin, "attackSuccess", script.cOwnID)}${cssTableCellButton}) }\}
 !mmm       else
 !mmm         chat: }\}
 !mmm       end if
 !mmm     else if isfumble(script.cDefenseRoll)
-!mmm       chat: {\{Kritischer Fehlschlag=${script.defenseResult} **Schwerer kritischer Treffer** [🎲](${m3mgdCriticalEffectRollPayload(script.cOwnID, "defenseFailure", m3mgdExchange.(m3mgdAttrAttackerID))}${cssTableCellButton}) }\}
+!mmm       chat: {\{Kritischer Fehlschlag=${script.defenseResult} **Schwerer kritischer Treffer** [🎲](${m3mgdCriticalEffectRollPayload(script.cOwnID, "defenseFailure", attackData.origin)}${cssTableCellButton}) }\}
 !mmm     else 
 !mmm       chat: {\{Ergebnis=${script.defenseResult} **Schwerer Treffer**}\}
 !mmm     end if
@@ -2737,7 +2669,7 @@
 !mmm       chat: {\{Schaden=**${effHealthLoss}&nbsp;LP&nbsp;/&nbsp;${effEnduranceLoss}&nbsp;AP**}\}
 !mmm     end if
 !mmm
-!mmm     if script.criticalAttack == true and m3mgdExchange.(m3mgdAttrAttackType) eq "magic"
+!mmm     if script.criticalAttack == true and attackData.attackType eq "magic"
 !mmm       chat: {\{Kritischer Zaubererfolg=
 !mmm       if script.defenseResult < 20
 !mmm         chat: Zauber wirkt **doppelt so stark** (Abwehrergebnis < 20, Schaden wurde verdoppelt)}\}

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgard()
 !mmm   
-!mmm   set libVersion = "libMidgard v1.6.0-pre (2025-04-16)"
+!mmm   set libVersion = "libMidgard v1.6.0-pre2 (2025-04-17)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
@@ -26,18 +26,10 @@
 !mmm     return false
 !mmm   end if
 !mmm
-!mmm   set m3mgdAttrAttackType          = "m3mgd_attack_type"
-!mmm   set m3mgdAttrAttackerID          = "m3mgd_attack_attackerID"
-!mmm   set m3mgdAttrAttackTargetID      = "m3mgd_attack_targetID"
-!mmm   set m3mgdAttrAttackResult        = "m3mgd_attack_result"
-!mmm   set m3mgdAttrAttackDamage        = "m3mgd_attack_damage"
-!mmm   set m3mgdAttrAttackDamageRoll    = "m3mgd_attack_damage_roll"
-!mmm   set m3mgdAttrAttackWeaponType    = "m3mgd_attack_weapon_type"
-!mmm   set m3mgdAttrAttackEnduranceCost = "m3mgd_attack_endurance_cost"
 !mmm   set m3mgdAttrHealthGain          = "m3mgd_health_gain"
 !mmm   set m3mgdAttrEnduranceGain       = "m3mgd_endurance_gain"
 !mmm
-!mmm   set m3mgdExchangeAttrList = m3mgdAttrAttackType, m3mgdAttrAttackerID, m3mgdAttrAttackTargetID, m3mgdAttrAttackResult, m3mgdAttrAttackDamage, m3mgdAttrAttackDamageRoll, m3mgdAttrAttackWeaponType, m3mgdAttrHealthGain, m3mgdAttrEnduranceGain
+!mmm   set m3mgdExchangeAttrList = m3mgdAttrHealthGain, m3mgdAttrEnduranceGain
 !mmm
 !mmm   set m3mgdValidMeleeAttackWeaponTypes = "waffenlos", "Einhandschwert", "Zweihandschwert", "Fechtwaffe", "Stichwaffe", "Stockwaffe", "Spießwaffe", "Kettenwaffe", "Einhandschlagwaffe", "Zweihandschlagwaffe", "Zauberstab"
 !mmm   set m3mgdValidRangedAttackWeaponTypes = "Bogen", "Kurzbogen", "Langbogen", "Kompositbogen", "schwere Armbrust", "leichte Armbrust", "Handarmbrust", "Schleuder", "Blasrohr", "Wurfspieß", "Wurfscheibe", "Wurfklinge", "Stielwurfwaffe"
@@ -89,9 +81,7 @@
 !mmm   set m3mgdAttrXPLog = "Erfahrungsprotokoll"
 !mmm
 !mmm   publish to game: m3mgdScriptCommands, m3mgdExchange
-!mmm   publish to game: m3mgdAttrAttackType, m3mgdAttrAttackerID, m3mgdAttrAttackTargetID, m3mgdAttrAttackResult, m3mgdAttrAttackDamage, m3mgdAttrAttackDamageRoll, m3mgdAttrAttackWeaponType, m3mgdAttrAttackEnduranceCost
-!mmm   publish to game: m3mgdAttrHealthGain, m3mgdAttrEnduranceGain
-!mmm   publish to game: m3mgdExchangeAttrList
+!mmm   publish to game: m3mgdAttrHealthGain, m3mgdAttrEnduranceGain, m3mgdExchangeAttrList
 !mmm   publish to game: m3mgdValidAttackWeaponTypes, m3mgdValidMeleeAttackWeaponTypes, m3mgdValidRangedAttackWeaponTypes
 !mmm   publish to game: m3mgdArmorPiercingWeaponTypes
 !mmm   publish to game: m3mgdParryLargeShieldTypes, m3mgdParrySmallShieldTypes, m3mgdParrySmallShieldEffectiveAgainst, m3mgdParryStandardTypes, m3mgdParryStandardEffectiveAgainst
@@ -114,11 +104,11 @@
 !mmm   publish to game: m3mgdSpellList, m3mgdListDefenseWeapons, m3mgdListMeleeAttackWeapons, m3mgdListRangedAttackWeapons
 !mmm   publish to game: m3mgdDefenseWeaponType, m3mgdMeleeWeaponType, m3mgdRangedWeaponProperties
 !mmm   publish to game: _m3mgdSpellButtonPayload, _m3mgdWeaponButtonPayload, m3mgdSpellSelectorChatMenu, m3mgdWeaponSelectorChatMenu, m3mgdRerunButton
-!mmm   publish to game: m3mgdDefenseDataEntryPayload, m3mgdDefenseInitPayload, m3mgdDefenseDataTable, m3mgdChatDefensePrompt
-!mmm   publish to game: m3mgdWeaponSpecialEffect, m3mgdInjuryFX, m3mgdEffectiveArmorProtection
 !mmm   publish to game: m3mgdGetCriticalEffect, m3mgdStorePersistentEffect, m3mgdExecuteCriticalEffect
 !mmm   publish to game: m3mgdCriticalEffectPrompt, m3mgdCriticalEffectRollPayload, m3mgdPersistentEffectLabels, m3mgdUpdatePersistentEffectsCounters
 !mmm   publish to game: m3mgdProcessCombatPP, m3mgdGetXPLog, _m3mgdLogXP, m3mgdEditXP, m3mgdProcessAttackXP, m3mgdProcessSkillXP, m3mgdProcessSpellXP, m3mgdXPEditButton
+!mmm   publish to game: m3mgdDefenseDataEntryPayload, m3mgdDefenseInitPayload, m3mgdDefenseDataTable, m3mgdChatDefensePrompt
+!mmm   publish to game: m3mgdProcessAttackerEffects, m3mgdWeaponSpecialEffect, m3mgdInjuryFX, m3mgdEffectiveArmorProtection
 !mmm
 !mmm   chat: ${libVersion} loaded.
 !mmm   
@@ -2411,9 +2401,6 @@
 !mmm     return false
 !mmm   end if
 !mmm   
-!mmm   if isdefault(attackerID)
-!mmm     set attackerID = m3mgdExchange.(m3mgdAttrAttackerID)
-!mmm   end if
 !mmm   if not isChar(attackerID)
 !mmm     do whisperback("m3mgdProcessAttackXP(): Unable to process experience for attack: attacker '" & attackerID.name & "' not linked to a character sheet.")
 !mmm     return false
@@ -2710,6 +2697,10 @@
 !mmm     do whisperback("m3mgdChatDefensePrompt() called without a valid attacker ID, defaulting to script.cOwnID failed.")
 !mmm     return false
 !mmm   end if
+!mmm
+!mmm   if not m3mgdStoreAttack(attackData) 
+!mmm     do whisperback("m3mgdChatDefensePrompt() unable to store attack data for defense script.")
+!mmm   end if
 !mmm   
 !mmm   if attackData.origin.PC 
 !mmm
@@ -2754,6 +2745,33 @@
 !mmm
 !mmm   return true
 !mmm   
+!mmm end function
+!rem
+!rem // m3mgdProcessAttackerEffects(attackData)
+!rem //
+!rem //   Registers effects of a completed attack on the attacker: practice points and endurance loss.
+!rem //
+!mmm function m3mgdProcessAttackerEffects(attackData)
+!mmm
+!rem   // Register practice point, if applicable
+!mmm   if attackData.criticalAttack and not m3mgdIsExhausted(attackData.target) and attackData.attackType eq "magic"
+!mmm     set log = { "Praxispunkt": "Für die Zauberkategorie **" & attackData.origin.(findattr(attackData.origin, "Zauber", "Zauber", attackData.magicSpell, "Prozess")) & "** bitte manuell notieren. [x](https://media.giphy.com/media/hKafco7mFwBioBxqFT/giphy.gif)}} " }
+!mmm   else if attackData.criticalAttack and not m3mgdIsExhausted(attackData.target)
+!mmm     do m3mgdProcessCombatPP(attackData.origin, attackData.weaponLabel, attackData.target)
+!mmm     set log = { "Praxispunkt": "[x](https://media.giphy.com/media/hKafco7mFwBioBxqFT/giphy.gif)" }
+!mmm   else if attackData.criticalAttack
+!mmm     set log = { "Kein Praxispunkt": "Gegner war schon erschöpft (AP=0)" }
+!mmm   end if
+!mmm
+!rem   // Register endurance loss for magic spells or magic weapons
+!mmm   set effEnduranceLoss = attackData.origin.(m3mgdGetEnduranceAttribute(attackData.origin)) - m3mgdModifyEndurance(-1 * attackData.magicEnduranceCost, attackData.origin, m3mgdGetEnduranceAttribute(attackData.origin))
+!mmm   if effEnduranceLoss > 0
+!mmm     set log = { log, "AP": "-" & effEnduranceLoss }
+!mmm     do m3mgdInjuryFX(attackData.origin, 0, effEnduranceLoss / attackData.origin.(m3mgdGetEnduranceAttribute(attackData.origin)).max)
+!mmm   end if
+!mmm
+!mmm   return log
+!mmm
 !mmm end function
 !rem
 !rem // m3mgdWeaponSpecialEffect(effect)

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgard()
 !mmm   
-!mmm   set libVersion = "libMidgard v1.6.0-pre2 (2025-04-17)"
+!mmm   set libVersion = "libMidgard v1.6.0-pre3 (2025-04-20)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
@@ -166,7 +166,7 @@
 !rem //   Returns name of a valid, preferred attribute to access the token's endurance.
 !rem // 
 !mmm function m3mgdGetEnduranceAttribute(tokenID)
-!mmm   if m3mgdValidateTokenAttribute(tokenID, script.cEnduranceAttr)
+!mmm   if tokenID.PC and m3mgdValidateTokenAttribute(tokenID, script.cEnduranceAttr)
 !mmm     return script.cEnduranceAttr
 !mmm   else if tokenID.PC
 !mmm     return m3mgdValidateTokenAttribute(tokenID, "AP")
@@ -199,8 +199,7 @@
 !mmm   set filter = { action: "combatAttack", origin: attackData.origin, target: attackData.target }
 !mmm   set activeAttacks = m3mgdExchangeGetData(m3mgdExchangeRegistries.combatData, filter)
 !mmm   if activeAttacks
-!mmm     debug chat: Overwriting previous attack data for the same origin against the same target (${activeAttacks}).
-!mmm     debug do m3mgdExchangeDelete(m3mgdExchangeRegistries.combatData, filter)
+!mmm     do m3mgdExchangeDelete(m3mgdExchangeRegistries.combatData, filter)
 !mmm   end if 
 !rem 
 !rem   // Store attackData
@@ -232,6 +231,10 @@
 !mmm     set searchCriteria = { searchCriteria, origin: originID }
 !mmm   end if 
 !mmm   set attackData = m3mgdExchangeGetData(dataExchangeID, searchCriteria)
+!mmm   if count(attackData) != 1
+!mmm     do whisperback("m3mgdRetrieveAttack(): Found more than one active attack by " & originID.token_name & " against " & targetID.token_name & ". Aborting.")
+!mmm     return false
+!mmm   end if
 !mmm
 !mmm   set validItems = 0
 !mmm   if attackData.origin.token_id
@@ -927,7 +930,7 @@
 !mmm   else if prvEndurance + offset <= 0
 !mmm     set effOffset = highlight(sign(0 - prvEndurance, "display"), "bad", "begrenzt auf Minimum 0")
 !mmm   else
-!mmm     set effOffset = highlight(sign(offset), "normal")
+!mmm     set effOffset = highlight(sign(offset, "display"), "normal")
 !mmm   end if 
 !mmm   
 !mmm   set newEndurance = prvEndurance + effOffset

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgard()
 !mmm   
-!mmm   set libVersion = "libMidgard v1.6.0-pre3 (2025-04-20)"
+!mmm   set libVersion = "libMidgard v1.6.0 (2025-04-21)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
@@ -17,9 +17,9 @@
 !rem
 !mmm   set m3mgdScriptCommands = { "magicAttack": "&#x25;{MacroSheet|magicAttack}", "defense": "&#x25;{MacroSheet|defense}", "resistance": "&#x25;{MacroSheet|defense}", "melee": "&#x25;{MacroSheet|meleeAttack}", "ranged": "&#x25;{MacroSheet|rangedAttack}" }
 !mmm   set m3mgdScriptCommands = { m3mgdScriptCommands, "editXP": "&#x25;{MacroSheet|editXP}", "managePersistentEffects": "&#x25;{MacroSheet|managePersistentEffects}", "defendFrostball": "&#x25;{MacroSheet|defendFrostball}", "defendSnatch": "&#x25;{MacroSheet|defendSnatch}" }
+!mmm
 !mmm   set m3mgdExchangeDataSheet = "MacroSheet"
 !mmm   set m3mgdExchange = m3mgdExchangeDataSheet.character_id
-!mmm 
 !mmm   if m3mgdExchange.permission ne "view" and m3mgdExchange.permission ne "control" 
 !mmm     do whisperback(libVersion & " - No permission to access Midgard data exchange sheet '" & m3mgdExchangeDataSheet & "'. Data exchange will not work.")
 !mmm     do delay(5)
@@ -140,25 +140,15 @@
 !rem //   Returns the attrLabel value found valid or false in case of validation or access issues.
 !rem // 
 !mmm function m3mgdValidateTokenAttribute(tokenID, attrLabel, defaultAttrLabel)
-!mmm 
 !mmm   if isunknown(tokenID.(attrLabel)) or isdenied(tokenID.(attrLabel))
-!mmm     
 !mmm     if isdefault(defaultAttrLabel) or isunknown(tokenID.(script.(defaultAttrLabel))) or isdenied(tokenID.(script.(defaultAttrLabel)))
-!mmm     
 !mmm       return false
-!mmm     
 !mmm     else
-!mmm     
 !mmm       return script.(defaultAttrLabel)
-!mmm     
 !mmm     end if
-!mmm     
 !mmm   else
-!mmm   
 !mmm     return attrLabel
-!mmm 
 !mmm   end if
-!mmm   
 !mmm end function
 !rem
 !rem // m3mgdGetEnduranceAttribute(tokenID)
@@ -207,32 +197,27 @@
 !mmm   
 !mmm end function
 !rem
-!rem // m3mgdRetrieveAttack(targetID, [originID], [dataExchangeID])
+!rem // m3mgdRetrieveAttack([targetID], [originID], [filters])
 !rem // 
 !rem //   Pulls stored attack data for the token pair targetID/[originID] from the registry [dataExchangeID].
 !rem //   Validates attack data stack and returns it if valid, otherwise returns false.
 !rem // 
-!mmm function m3mgdRetrieveAttack(targetID, originID, dataExchangeID)
+!mmm function m3mgdRetrieveAttack(targetID, originID, filters)
 !mmm
-!mmm   if isdefault(targetID) or isunknown(targetID.token_id)
-!mmm     do whisperback("m3mgdRetrieveAttack(): No target ID given, aborting.")
-!mmm     return false
-!mmm   end if
-!mmm   if isdefault(dataExchangeID)
-!mmm     set dataExchangeID = m3mgdExchangeRegistries.combatData
-!mmm   end if
-!mmm   if isunknown(dataExchangeID) or isdenied(dataExchangeID)
-!mmm     do whisperback("m3mgdRetrieveAttack(): Invalid attack data exchange sheet: " & getreason(dataExchangeID))
-!mmm     return false
-!mmm   end if
-!mmm
-!mmm   set searchCriteria = { action: "combatAttack", target: targetID }
+!mmm   set searchCriteria = { action: "combatAttack" }
+!mmm   if not isdefault(targetID)
+!mmm     set searchCriteria = { searchCriteria, target: targetID }
+!mmm   end if 
 !mmm   if not isdefault(originID)
 !mmm     set searchCriteria = { searchCriteria, origin: originID }
 !mmm   end if 
-!mmm   set attackData = m3mgdExchangeGetData(dataExchangeID, searchCriteria)
+!mmm   if not isdefault(filters)
+!mmm     set searchCriteria = { searchCriteria, filters }
+!mmm   end if 
+!mmm
+!mmm   set attackData = m3mgdExchangeGetData(m3mgdExchangeRegistries.combatData, searchCriteria)
 !mmm   if count(attackData) != 1
-!mmm     do whisperback("m3mgdRetrieveAttack(): Found more than one active attack by " & originID.token_name & " against " & targetID.token_name & ". Aborting.")
+!mmm     debug chat: m3mgdRetrieveAttack(): Found more than one active attack by '${originID.token_name}' against '${targetID.token_name}'.
 !mmm     return false
 !mmm   end if
 !mmm

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -2774,9 +2774,9 @@
 !mmm
 !mmm end function
 !rem
-!rem // m3mgdWeaponSpecialEffect(effect)
+!rem // m3mgdWeaponSpecialEffect(effect, attackerID, [targetID])
 !rem //
-!mmm function m3mgdWeaponSpecialEffect(effect, attackerID)
+!mmm function m3mgdWeaponSpecialEffect(effect, attackerID, targetID)
 !mmm
 !mmm   if isdefault(effect)
 !mmm     return false
@@ -2784,11 +2784,11 @@
 !mmm
 !mmm   if effect eq "waterWalkerBlastEffect"
 !mmm     
-!mmm     do m3mgdRuneEffectWaterWalker(attackerID, default, "water-blast")
+!mmm     return m3mgdRuneEffectWaterWalker(attackerID, targetID, "water-blast")
 !mmm     
 !mmm   end if
 !mmm     
-!mmm   return true
+!mmm   return false
 !mmm
 !mmm end function
 !rem

--- a/examples/midgard/libMidgardGlobal/libMidgard.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgard.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgard()
 !mmm   
-!mmm   set libVersion = "libMidgard v1.6.0-WIP7 (2025-04-16)"
+!mmm   set libVersion = "libMidgard v1.6.0-pre (2025-04-16)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // MMM compatibility check: die if MMM version too low
@@ -101,7 +101,7 @@
 !rem
 !mmm   publish to game: m3mgdValidateOwnTokenID, m3mgdValidateTokenAttribute
 !mmm   publish to game: m3mgdGetEnduranceAttribute, m3mgdGetHealthAttribute
-!mmm   publish to game: m3mgdStoreAttack, m3mgdRetrieveAttack, _m3mgdExecuteCode, m3mgdRollChanceEffect, m3mgdFlushExchange
+!mmm   publish to game: m3mgdStoreAttack, m3mgdRetrieveAttack, m3mgdModifyAttackDamage, _m3mgdExecuteCode, m3mgdRollChanceEffect, m3mgdFlushExchange
 !mmm   publish to game: _m3mgdHandleStoredAttr, m3mgdSetAttrCeiling, m3mgdAttrCeiling, m3mgdReleaseAttrCeiling
 !mmm   publish to game: m3mgdHasActivePersistentEffects, m3mgdGetActivePersistentEffects, m3mgdRemovePersistentEffect
 !mmm   publish to game: m3mgdRemovePersistentEffectPayload, m3mgdShowPersistentEffectsPayload
@@ -283,6 +283,14 @@
 !mmm     return false
 !mmm   end if
 !mmm
+!mmm end function
+!rem
+!rem // m3mgdModifyAttackDamage(originID, targetID, attackType, attackResult, damageResult, newDamage)
+!rem // 
+!rem //   Modifies the data identified by the first several arguments by overwriting their damageResult property with newDamage. Wrapper function to get around Roll20 chat buttons' incompatibility with MMM struct syntax (:).
+!rem // 
+!mmm function m3mgdModifyAttackDamage(originID, targetID, attackType, attackResult, damageResult, newDamage)
+!mmm   return m3mgdExchangeEdit(m3mgdExchangeRegistries.combatData, { action: "combatAttack", attackType: attackType, origin: originID.token_id, target: targetID.token_id, attackResult: attackResult, damageResult: damageResult }, { damageResult: newDamage, damageRoll: newDamage })
 !mmm end function
 !rem
 !rem // _m3mgdExecuteCode(codeLines, myID, foeID)
@@ -1761,13 +1769,13 @@
 !mmm
 !mmm end function
 !rem
-!rem // m3mgdSpellSelectorChatMenu([tokenID], [combatMode], [attackSpellType], [spellDamage])
+!rem // m3mgdSpellSelectorChatMenu([tokenID], [combatMode], [attackSpellType], [attackerID], [spellDamage])
 !rem //
 !rem //   Returns code for a chat menu for tokenID to select among spells.
 !rem //   Buttons execute a customize block to hand over the chosen weapon to the relevant script. 
 !rem //   Scripts called differ between player characters (identified by the attribute "PC" evaluating as true) and NPCs.
 !rem //
-!mmm function m3mgdSpellSelectorChatMenu(tokenID, combatMode, attackSpellType, spellDamage)  
+!mmm function m3mgdSpellSelectorChatMenu(tokenID, combatMode, attackSpellType, attackerID, spellDamage)  
 !mmm   
 !mmm   if isdefault(tokenID)
 !mmm     set tokenID = sender.token_id
@@ -1798,19 +1806,10 @@
 !mmm   
 !mmm   else if combatMode eq "defense" and attackSpellType eq "Umgebung"
 !mmm   
-!mmm     do setattr(m3mgdExchange, m3mgdAttrAttackDamage, spellDamage)
-!mmm     do setattr(m3mgdExchange, m3mgdAttrAttackDamageRoll, spellDamage)
 !mmm     return m3mgdWeaponSelectorChatMenu(tokenID, "defense", "magic")
 !mmm   
 !mmm   else if combatMode eq "defense" and (attackSpellType eq "Geist" or attackSpellType eq "Körper")
 !mmm   
-!mmm     if isdefault(spellDamage)
-!mmm       do whisperback("Schadenseingabe fehlt.")
-!mmm     else
-!mmm       if setattr(m3mgdExchange, m3mgdAttrAttackDamage, spellDamage) + setattr(m3mgdExchange, m3mgdAttrAttackDamageRoll, spellDamage) != spellDamage / 2
-!mmm         do whisperback("Schaden konnte nicht gespeichert werden.")
-!mmm       end if
-!mmm     end if
 !mmm     set selectorPrompt = "Resistenz gegen Zauber"
 !mmm     set noDefensePayload = "!mmm customize&#13;"
 !mmm     set noDefensePayload = noDefensePayload & "!mmm set cOwnID&#x3D;&#x22;" & tokenID & "&#x22;&#13;"
@@ -2697,52 +2696,62 @@
 !mmm   
 !mmm end function
 !rem
-!rem // m3mgdChatDefensePrompt(targetID, [attackerID], weaponType, weaponsGroup)
+!rem // m3mgdChatDefensePrompt(attackData)
 !rem //
-!mmm function m3mgdChatDefensePrompt(targetID, attackerID, weaponType, weaponsGroup)
+!mmm function m3mgdChatDefensePrompt(attackData)
 !mmm   
-!mmm   if isdefault(targetID) or not m3mgdValidateOwnTokenID(targetID)
+!mmm   if isdefault(attackData.target) or not m3mgdValidateOwnTokenID(attackData.target)
 !mmm     do whisperback("m3mgdChatDefensePrompt() called without a valid target ID.")
 !mmm     return false
 !mmm   end if
-!mmm   if (isdefault(attackerID) or not m3mgdValidateOwnTokenID(attackerID)) and m3mgdValidateOwnTokenID(script.cOwnID)
-!mmm     set attackerID = script.cOwnID
-!mmm   else if isdefault(attackerID)
+!mmm   if (isdefault(attackData.origin) or not m3mgdValidateOwnTokenID(attackData.origin)) and m3mgdValidateOwnTokenID(script.cOwnID)
+!mmm     set attackData = { attackData, origin: script.cOwnID }
+!mmm   else if isdefault(attackData.origin)
 !mmm     do whisperback("m3mgdChatDefensePrompt() called without a valid attacker ID, defaulting to script.cOwnID failed.")
 !mmm     return false
 !mmm   end if
 !mmm   
-!mmm   if attackerID.PC 
+!mmm   if attackData.origin.PC 
 !mmm
-!mmm     set sender = targetID.token_name
+!mmm     set sender = attackData.target.token_name
 !mmm     if weaponsGroup eq "magic"
-!mmm       set attackSpellType = attackerID.(findattr(attackerID, "Zauber", "Zauber", weaponType, "Ziel"))
-!mmm       chat: /w "${targetID.character_name}" ${m3mgdSpellSelectorChatMenu(targetID, "defense", attackSpellType)}
+!mmm       chat: /w "${targetID.character_name}" ${m3mgdSpellSelectorChatMenu(targetID, "defense", attackData.spellType)}
 !mmm     else 
-!mmm       chat: /w "${targetID.character_name}" ${m3mgdWeaponSelectorChatMenu(targetID, "defense", weaponType)}
+!mmm       chat: /w "${targetID.character_name}" ${m3mgdWeaponSelectorChatMenu(targetID, "defense", attackData.weaponType)}
 !mmm     end if
 !mmm
 !mmm   else
 !mmm
-!mmm     set sender = attackerID.token_name
-!mmm     set attackNarrative = "**" & targetID.token_name & "**, aufpassen! Ich mach dich platt! Wenn du nicht sofort reagierst, sieht es düster aus... "
-!mmm     set approvePayload = "!mmm script&#13;"
-!mmm     set approvePayload = approvePayload & literal("!mmm do chat('" & attackerID.token_name & "', '" & attackNarrative & "')") & "&#13;"
+!mmm     set sender = attackData.origin.token_name
+!mmm     set attackNarrative = "**" & attackData.target.token_name & "**, aufpassen! Ich mach dich platt! Wenn du nicht sofort reagierst, sieht es düster aus... "
 !mmm
-!mmm     if weaponsGroup eq "magic"
-!mmm       set attackSpellType = attackerID.(findattr(attackerID, "Zauber", "Zauber", weaponType, "Ziel"))
+!mmm     set approvePayload = "!mmm script&#13;"
+!mmm     set approvePayload = approvePayload & literal("!mmm do chat('" & attackData.origin.token_name & "', '" & attackNarrative & "')") & "&#13;"
+!mmm
+!mmm     set modifyDamagePayload = "!mmm script&#13;"
+!mmm     set modifyDamagePayload = modifyDamagePayload & literal("!mmm do chat('" & attackData.origin.token_name & "', '" & attackNarrative & "')") & "&#13;"
+!mmm     set modifyDamagePayload = modifyDamagePayload & literal("!mmm set newDamage='?" & "{Schadenspunkte, falls Resistenz/Abwehr misslingt|}'") & "&#13;"
+!mmm     set modifyDamagePayload = modifyDamagePayload & literal("!mmm do m3mgdModifyAttackDamage('" & attackData.origin & "', '" & attackData.target & "', '" & attackData.attackType & "', " & attackData.attackResult & ", default, newDamage)") & "&#13;"
+!mmm
+!mmm     if attackData.attackType eq "magic"
 !mmm       set approvePayload = approvePayload & literal("!mmm set attackDamage='?" & "{Schadenspunkte, falls Resistenz/Abwehr misslingt|}'") & "&#13;"
-!mmm       set approvePayload = approvePayload & literal("!mmm do chat('" & attackerID.token_name & "', '/w \"" & targetID.character_name & "\" ' & m3mgdSpellSelectorChatMenu(\"" & targetID & "\", \"defense\", \"" & attackSpellType & "\", attackDamage))") & "&#13;"
-!mmm       set rerollPayload = _m3mgdSpellButtonPayload(attackerID, weaponType, default, { cTargetID: targetID, cManualModifiers: script.cManualModifiers })
+!mmm       set approvePayload = approvePayload & literal("!mmm do m3mgdModifyAttackDamage('" & attackData.origin & "', '" & attackData.target & "', '" & attackData.attackType & "', " & attackData.attackResult & ", default, attackDamage)") & "&#13;"
+!mmm       set approvePayload = approvePayload & literal("!mmm do chat('" & attackData.origin.token_name & "', '/w \"" & attackData.target.character_name & "\" ' & m3mgdSpellSelectorChatMenu(\"" & attackData.target & "\", \"defense\", \"" & attackData.spellType & "\", \"" & attackData.origin & "\", attackDamage))") & "&#13;"
+!mmm       set modifyDamagePayload = modifyDamagePayload & literal("!mmm do chat('" & attackData.origin.token_name & "', '/w \"" & attackData.target.character_name & "\" ' & m3mgdSpellSelectorChatMenu(\"" & attackData.target & "\", \"defense\", \"" & attackData.spellType & "\", \"" & attackData.origin & "\", attackDamage))") & "&#13;"
+!mmm       set rerollPayload = _m3mgdSpellButtonPayload(attackData.origin, attackData.magicSpell, default, { cTargetID: attackData.target, cManualModifiers: script.cManualModifiers })
 !mmm     else 
-!mmm       set approvePayload = approvePayload & literal("!mmm do chat('" & attackerID.token_name & "', '/w \"" & targetID.character_name & "\" ' & m3mgdWeaponSelectorChatMenu(\"" & targetID & "\", \"defense\", \"" & weaponType & "\"))") & "&#13;"
-!mmm       set rerollPayload = _m3mgdWeaponButtonPayload(attackerID, weaponsGroup, script.cWeaponLabel, default, { cTargetID: targetID, cSemiManualModifiers: script.cSemiManualModifiers, cManualModifiers: script.cManualModifiers })
+!mmm       set approvePayload = approvePayload & literal("!mmm do chat('" & attackData.origin.token_name & "', '/w \"" & attackData.target.character_name & "\" ' & m3mgdWeaponSelectorChatMenu(\"" & attackData.target & "\", \"defense\", \"" & attackData.weaponType & "\"))") & "&#13;"
+!mmm       set modifyDamagePayload = modifyDamagePayload & literal("!mmm do chat('" & attackData.origin.token_name & "', '/w \"" & attackData.target.character_name & "\" ' & m3mgdWeaponSelectorChatMenu(\"" & attackData.target & "\", \"defense\", \"" & attackData.weaponType & "\"))") & "&#13;"
+!mmm       set rerollPayload = _m3mgdWeaponButtonPayload(attackData.origin, attackData.attackType, script.cWeaponLabel, default, { cTargetID: attackData.target, cSemiManualModifiers: script.cSemiManualModifiers, cManualModifiers: script.cManualModifiers })
 !mmm     end if
 !mmm
 !mmm     set approvePayload = approvePayload & "!mmm end script&#13;"
+!mmm     set modifyDamagePayload = modifyDamagePayload & "!mmm end script&#13;"
 !mmm
-!mmm     chat: /w GM [🖅 **an ${targetID.character_name}**](${approvePayload}) &nbsp; *oder* &nbsp; [🎲 nochmal würfeln](${rerollPayload})
+!mmm     chat: /w GM [✅ & 🖅 **an ${attackData.target.character_name}**](${approvePayload})&nbsp;&nbsp;[💥 Schaden ändern](${modifyDamagePayload})&nbsp;&nbsp;[🎲🗘 nochmal würfeln](${rerollPayload})
+!mmm
 !mmm   end if
+!mmm
 !mmm   return true
 !mmm   
 !mmm end function

--- a/examples/midgard/libMidgardGlobal/libMidgardRuneBlades.mmm
+++ b/examples/midgard/libMidgardGlobal/libMidgardRuneBlades.mmm
@@ -4,7 +4,7 @@
 !rem //
 !mmm function _libMidgardRuneBlades()
 !mmm   
-!mmm   set libVersion = "libMidgardRuneBlades v1.1.1 (2024-02-14)"
+!mmm   set libVersion = "libMidgardRuneBlades v1.1.2 (2025-04-17)"
 !mmm   set sender = "MacroSheetLibrary"
 !mmm
 !rem   // Game-global constants for publication
@@ -327,9 +327,6 @@
 !mmm     return false
 !mmm   end if
 !mmm
-!mmm   if isdefault(targetID)
-!mmm     set targetID = m3mgdExchange.(m3mgdAttrAttackTargetID)
-!mmm   end if
 !mmm   if isunknown(targetID) or isdenied(targetID) or targetID.permission ne "control"
 !mmm     do whisperback("Target given as token ID '" & targetID & "' may not be a correct token ID, or does not allow control of attributes")
 !mmm     return false

--- a/examples/midgard/magicAttack/magicAttack.mmm
+++ b/examples/midgard/magicAttack/magicAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Magic Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "1.0.1pre (2025-03-12)"
+!mmm   set scriptVersion = "magicAttack 1.1.0-WIP (2025-04-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -139,7 +139,11 @@
 !mmm 
 !rem   // Save key attack data for defense script
 !mmm   if attackResult >= 20 and not isfumble(cAttackRoll)
-!mmm     if not m3mgdExchangeStoreAttack("magic", cAttackSpell) 
+!mmm     set attackData = { origin: cOwnID.token_id, target: cTargetID.token_id, action: "combatAttack", attackType: "magic", attackResult: attackResult, criticalAttack: criticalAttack, magicSpell: cAttackSpell, spellType: cSpellType }
+!mmm     if magicEnduranceCost
+!mmm       set attackData = { attackData, magicEnduranceCost: magicEnduranceCost }
+!mmm     end if
+!mmm     if not m3mgdStoreAttack(attackData) 
 !mmm       do whisperback("Problem bei der Datenablage für das Abwehrskript; Angriffsdaten bitte manuell ergänzen.")
 !mmm     end if
 !mmm   end if
@@ -223,7 +227,7 @@
 !mmm     do m3mgdInjuryFX(cOwnID, 0, effEnduranceLoss / cOwnID.(m3mgdGetEnduranceAttribute(cOwnID)).max)
 !mmm   end if
 !mmm   if attackResult >= 20 and not isfumble(cAttackRoll)
-!mmm     do m3mgdChatDefensePrompt(cTargetID, cOwnID, cAttackSpell, "magic")
+!mmm     do m3mgdChatDefensePrompt(attackData)
 !mmm   end if
 !mmm
 !mmm end script

--- a/examples/midgard/magicAttack/magicAttack.mmm
+++ b/examples/midgard/magicAttack/magicAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Magic Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "magicAttack 1.1.0-pre2 (2025-04-17)"
+!mmm   set scriptVersion = "magicAttack 1.1.0 (2025-04-17)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion

--- a/examples/midgard/magicAttack/magicAttack.mmm
+++ b/examples/midgard/magicAttack/magicAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Magic Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "magicAttack 1.1.0-WIP (2025-04-16)"
+!mmm   set scriptVersion = "magicAttack 1.1.0-pre2 (2025-04-17)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -65,7 +65,7 @@
 !rem   // Refetch token id to ensure access in case of erroneous override in customize block
 !mmm   set cOwnID = m3mgdValidateOwnTokenID(cOwnID)
 !mmm   if not cOwnID
-!mmm     do whisperback(scriptVersion & ": Invalid own token ID configured. Check custom config script.")
+!mmm     do whisperback(scriptVersion & ": Invalid own token ID configured. Check custom config script or select an NPC token.")
 !mmm     exit script
 !mmm   end if
 !rem
@@ -124,7 +124,6 @@
 !mmm
 !rem   // Process endurance cost for spellcasting
 !mmm   if magicEnduranceCost > 0
-!mmm     set effEnduranceLoss = cOwnID.(m3mgdGetEnduranceAttribute(cOwnID)) - m3mgdModifyEndurance(-1 * magicEnduranceCost, cOwnID, m3mgdGetEnduranceAttribute(cOwnID))
 !mmm     set modifierLog = modifierLog & "{{ " & cAttackSpell & "=-" & magicEnduranceCost & " AP }}"
 !mmm   end if
 !rem
@@ -137,24 +136,6 @@
 !mmm   end if
 !mmm   set criticalAttack = iscritical(cAttackRoll)
 !mmm 
-!rem   // Save key attack data for defense script
-!mmm   if attackResult >= 20 and not isfumble(cAttackRoll)
-!mmm     set attackData = { origin: cOwnID.token_id, target: cTargetID.token_id, action: "combatAttack", attackType: "magic", attackResult: attackResult, criticalAttack: criticalAttack, magicSpell: cAttackSpell, spellType: cSpellType }
-!mmm     if magicEnduranceCost
-!mmm       set attackData = { attackData, magicEnduranceCost: magicEnduranceCost }
-!mmm     end if
-!mmm     if not m3mgdStoreAttack(attackData) 
-!mmm       do whisperback("Problem bei der Datenablage für das Abwehrskript; Angriffsdaten bitte manuell ergänzen.")
-!mmm     end if
-!mmm   end if
-!mmm
-!rem   // Register practice point, if applicable
-!mmm   if iscritical(cAttackRoll) and foeEndurance > 0
-!mmm     set modifierLog = modifierLog & " {{Praxispunkt=Für die Zauberkategorie **" & cOwnID.(findattr(cOwnID, "Zauber", "Zauber", cAttackSpell, "Prozess")) & "** bitte manuell notieren. [x](https://media.giphy.com/media/hKafco7mFwBioBxqFT/giphy.gif)}} "
-!mmm   else if iscritical(cAttackRoll)
-!mmm     set modifierLog = modifierLog & " {{Kein Praxispunkt=Gegner war schon erschöpft (AP=0)}} "
-!mmm   end if
-!mmm
 !mmm
 !mmm   if cVerbose
 !mmm     combine chat
@@ -218,16 +199,24 @@
 !mmm     set modifierLog = modifierLog & " {{ Angriffszähler=" & endOfActionSummary & " }}"
 !mmm   end if
 !mmm
+!rem   // Send modifier table to acting player
 !mmm   if modifierLog ne "{{Boni/Mali=keine}}"
 !mmm     chat: /w "${cOwnID.character_name}" ${"&"}{template:default} ${modifierLog}
 !mmm   end if
 !mmm
-!rem   // Injury & exhaustion special effects
-!mmm   if effEnduranceLoss > 0
-!mmm     do m3mgdInjuryFX(cOwnID, 0, effEnduranceLoss / cOwnID.(m3mgdGetEnduranceAttribute(cOwnID)).max)
-!mmm   end if
+!rem   // If attack was successful, send all the data onward to GM or target for defense and further processing
 !mmm   if attackResult >= 20 and not isfumble(cAttackRoll)
+!mmm
+!mmm     set attackData = { origin: cOwnID.token_id, target: cTargetID.token_id, action: "combatAttack", attackType: "magic" }
+!mmm     set attackData = { attackData, attackResult: attackResult, criticalAttack: criticalAttack, magicSpell: cAttackSpell, spellType: cSpellType }
+!mmm     if magicEnduranceCost
+!mmm       set attackData = { attackData, magicEnduranceCost: magicEnduranceCost }
+!mmm     end if
 !mmm     do m3mgdChatDefensePrompt(attackData)
+!mmm
+!rem   // Injury & exhaustion special effects in case of failure (otherwise they will be processed elsewhere)
+!mmm   else if effEnduranceLoss > 0
+!mmm     do m3mgdInjuryFX(cOwnID, 0, effEnduranceLoss / cOwnID.(m3mgdGetEnduranceAttribute(cOwnID)).max)
 !mmm   end if
 !mmm
 !mmm end script

--- a/examples/midgard/meleeAttack/meleeAttack.mmm
+++ b/examples/midgard/meleeAttack/meleeAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Melee Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "meleeAttack v2.1.0-WIP (2024-04-16)"
+!mmm   set scriptVersion = "meleeAttack v2.1.0-WIP2 (2024-04-16)"
 !rem
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -368,7 +368,7 @@
 !mmm   end if
 !mmm
 !mmm   if attackResult >= 20 and not isfumble(cAttackRoll)
-!mmm     do m3mgdChatDefensePrompt(cTargetID, cOwnID, cWeaponType, "melee")
+!mmm     do m3mgdChatDefensePrompt(attackData)
 !mmm   end if
 !mmm
 !mmm end script

--- a/examples/midgard/meleeAttack/meleeAttack.mmm
+++ b/examples/midgard/meleeAttack/meleeAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Melee Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "meleeAttack v2.1.0-WIP2 (2024-04-16)"
+!mmm   set scriptVersion = "meleeAttack v2.1.0-pre (2024-04-17)"
 !rem
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -240,32 +240,11 @@
 !mmm     set damageResult = highlight(damageResult, default, damageResultLog)
 !mmm   end if
 !mmm
-!rem   // Save key attack data for defense script
-!rem
-!mmm   if attackResult >= 20 and not isfumble(cAttackRoll) and damageResult > 0
-!mmm     set attackData = { origin: cOwnID.token_id, target: cTargetID.token_id, action: "combatAttack", attackType: "melee", attackResult: attackResult, criticalAttack: criticalAttack, damageResult: damageResult, damageRoll: cDamageRoll, weaponType: cWeaponType }
-!mmm     if cMagicEnduranceCost
-!mmm       set attackData = { attackData, magicEnduranceCost: cMagicEnduranceCost }
-!mmm     end if
-!mmm     if not m3mgdStoreAttack(attackData) 
-!mmm       do whisperback("Problem bei der Datenablage für das Abwehrskript; Angriffsdaten bitte manuell ergänzen.")
-!mmm     end if
-!mmm   end if
-!rem
 !rem   // Break down magic effects for player and GM
 !mmm   if magicExtraDamageActive and attackResult >= 20 and not isfumble(cAttackRoll) and damageResult > 0
 !mmm     set modifierLog = modifierLog & " {{Zauberwaffe=**" & (damageResult - cMagicExtraDamageRoll) & "**&nbsp;" & emojiMagic & " +&nbsp;**" & cMagicExtraDamageRoll & "**&nbsp;" & cMagicExtraDamageLabel & "}} "
 !mmm   else if magicWeapon and attackResult >= 20 and not isfumble(cAttackRoll) and damageResult > 0
 !mmm     set modifierLog = modifierLog & " {{Zauberwaffe=**" & damageResult & "**&nbsp;" & emojiMagic & " }} "
-!mmm   end if
-!mmm
-!rem   // Register practice point, if applicable
-!mmm   if iscritical(cAttackRoll) and not m3mgdIsExhausted(cTargetID)
-!mmm     if m3mgdProcessCombatPP(cOwnID, cWeaponLabel, cTargetID)
-!mmm       set modifierLog = modifierLog & " {{Praxispunkt=[x](https://media.giphy.com/media/hKafco7mFwBioBxqFT/giphy.gif)}} "
-!mmm     end if
-!mmm   else if iscritical(cAttackRoll)
-!mmm     set modifierLog = modifierLog & " {{Kein Praxispunkt=Gegner war schon erschöpft (AP=0)}} "
 !mmm   end if
 !mmm
 !rem   // Pull together a sensible guess at a default way of addressing the weapon for output
@@ -367,8 +346,20 @@
 !mmm     chat: /w "${cOwnID.character_name}" ${"&"}{template:default} ${modifierLog}
 !mmm   end if
 !mmm
+!rem   // Save key attack data for defense script
+!rem
 !mmm   if attackResult >= 20 and not isfumble(cAttackRoll)
+!mmm
+!mmm     set attackData = { origin: cOwnID.token_id, target: cTargetID.token_id, action: "combatAttack", attackType: "melee", attackResult: attackResult }
+!mmm     set attackData = { attackData, criticalAttack: criticalAttack, damageResult: damageResult, damageRoll: cDamageRoll, weaponType: cWeaponType, weaponLabel: cWeaponLabel }
+!mmm     if cMagicEnduranceCost
+!mmm       set attackData = { attackData, magicEnduranceCost: cMagicEnduranceCost }
+!mmm     end if
+!mmm     if not m3mgdStoreAttack(attackData) 
+!mmm       do whisperback("Problem bei der Datenablage für das Abwehrskript; Angriffsdaten bitte manuell ergänzen.")
+!mmm     end if
 !mmm     do m3mgdChatDefensePrompt(attackData)
+!mmm
 !mmm   end if
 !mmm
 !mmm end script

--- a/examples/midgard/meleeAttack/meleeAttack.mmm
+++ b/examples/midgard/meleeAttack/meleeAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Melee Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "meleeAttack v2.0.0 (2024-03-16)"
+!mmm   set scriptVersion = "meleeAttack v2.1.0-WIP (2024-04-16)"
 !rem
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -243,7 +243,11 @@
 !rem   // Save key attack data for defense script
 !rem
 !mmm   if attackResult >= 20 and not isfumble(cAttackRoll) and damageResult > 0
-!mmm     if not m3mgdExchangeStoreAttack("melee") 
+!mmm     set attackData = { origin: cOwnID.token_id, target: cTargetID.token_id, action: "combatAttack", attackType: "melee", attackResult: attackResult, criticalAttack: criticalAttack, damageResult: damageResult, damageRoll: cDamageRoll, weaponType: cWeaponType }
+!mmm     if cMagicEnduranceCost
+!mmm       set attackData = { attackData, magicEnduranceCost: cMagicEnduranceCost }
+!mmm     end if
+!mmm     if not m3mgdStoreAttack(attackData) 
 !mmm       do whisperback("Problem bei der Datenablage für das Abwehrskript; Angriffsdaten bitte manuell ergänzen.")
 !mmm     end if
 !mmm   end if

--- a/examples/midgard/meleeAttack/meleeAttack.mmm
+++ b/examples/midgard/meleeAttack/meleeAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Melee Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "meleeAttack v2.1.0-pre (2024-04-17)"
+!mmm   set scriptVersion = "meleeAttack v2.1.0 (2024-04-17)"
 !rem
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion

--- a/examples/midgard/rangedAttack/rangedAttack.mmm
+++ b/examples/midgard/rangedAttack/rangedAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Ranged Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "2.1.0WIP2 (2025-04-16)"
+!mmm   set scriptVersion = "2.1.0pre (2025-04-17)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -355,12 +355,6 @@
 !mmm     set attackFromBehind = false
 !mmm   end if
 !mmm
-!rem   // For magic weapons: Process optional endurance cost
-!mmm   if cMagicEnduranceCost > 0
-!mmm     set effEnduranceLoss = cOwnID.(m3mgdGetEnduranceAttribute(cOwnID)) - m3mgdModifyEndurance(-1 * cMagicEnduranceCost, cOwnID, m3mgdGetEnduranceAttribute(cOwnID))
-!mmm     set modifierLog = modifierLog & "{{ " & cWeaponLabel & "=-" & cMagicEnduranceCost & " AP }}"
-!mmm   end if
-!rem
 !rem   // Run & format rolls
 !rem
 !mmm   if cSemiManualModifiers % 23 == 0
@@ -423,29 +417,9 @@
 !mmm     set damageResult = highlight(damageResult, default, damageResultLog)
 !mmm   end if
 !mmm
-!rem   // Save key attack data for defense script
-!mmm   if attackResult >= 20 and not isfumble(cAttackRoll) and damageResult > 0
-!mmm     set attackData = { origin: cOwnID.token_id, target: cTargetID.token_id, action: "combatAttack", attackType: "ranged", attackResult: attackResult, criticalAttack: criticalAttack, damageResult: damageResult, damageRoll: cDamageRoll, weaponType: cWeaponType }
-!mmm     if cMagicEnduranceCost
-!mmm       set attackData = { attackData, magicEnduranceCost: cMagicEnduranceCost }
-!mmm     end if
-!mmm     if not m3mgdStoreAttack(attackData) 
-!mmm       do whisperback("Problem bei der Datenablage für das Abwehrskript; Angriffsdaten bitte manuell ergänzen.")
-!mmm     end if
-!mmm   end if
-!rem
 !rem   // Break down extra magic damage to player and GM
 !mmm   if cAmmoMagic and attackResult >= 20 and not isfumble(cAttackRoll) and damageResult > 0
 !mmm     set modifierLog = modifierLog & " {{Zauberschaden=" & damageResult & " }} "
-!mmm   end if
-!mmm
-!rem   // Register practice point, if applicable
-!mmm   if iscritical(cAttackRoll) and foeEndurance > 0
-!mmm     if m3mgdProcessCombatPP(cOwnID, cWeaponLabel, cTargetID)
-!mmm       set modifierLog = modifierLog & " {{Praxispunkt=[x](https://media.giphy.com/media/hKafco7mFwBioBxqFT/giphy.gif)}} "
-!mmm     end if
-!mmm   else if iscritical(cAttackRoll)
-!mmm     set modifierLog = modifierLog & " {{Kein Praxispunkt=Gegner war schon erschöpft (AP=0)}} "
 !mmm   end if
 !mmm
 !rem   // Pull together a sensible guess at a default way of addressing the weapon for output
@@ -556,12 +530,22 @@
 !mmm     chat: /w "${cOwnID.character_name}" ${"&"}{template:default} ${modifierLog}
 !mmm   end if
 !mmm
-!rem   // Injury & exhaustion special effects
-!mmm   if effEnduranceLoss > 0
-!mmm     do m3mgdInjuryFX(cOwnID, 0, effEnduranceLoss / cOwnID.(m3mgdGetEnduranceAttribute(cOwnID)).max)
-!mmm   end if
 !mmm   if attackResult >= 20 and not isfumble(cAttackRoll)
+!mmm
+!rem     // Save key attack data for defense script
+!mmm     set attackData = { origin: cOwnID.token_id, target: cTargetID.token_id, action: "combatAttack", attackType: "ranged", attackResult: attackResult }
+!mmm     set attackData = { attackData, criticalAttack: criticalAttack, damageResult: damageResult, damageRoll: cDamageRoll, weaponType: cWeaponType, weaponLabel: cWeaponLabel }
+!mmm     if cMagicEnduranceCost
+!mmm       set attackData = { attackData, magicEnduranceCost: cMagicEnduranceCost }
+!mmm     end if
+!mmm     if not m3mgdStoreAttack(attackData) 
+!mmm       do whisperback("Problem bei der Datenablage für das Abwehrskript; Angriffsdaten bitte manuell ergänzen.")
+!mmm     end if
 !mmm     do m3mgdChatDefensePrompt(attackData)
+!mmm
+!rem   // Injury & exhaustion special effects
+!mmm   else if cMagicEnduranceCost > 0
+!mmm     do m3mgdInjuryFX(cOwnID, 0, cMagicEnduranceCost / cOwnID.(m3mgdGetEnduranceAttribute(cOwnID)).max)
 !mmm   end if
 !mmm
 !mmm end script

--- a/examples/midgard/rangedAttack/rangedAttack.mmm
+++ b/examples/midgard/rangedAttack/rangedAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Ranged Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "2.1.0WIP (2025-04-16)"
+!mmm   set scriptVersion = "2.1.0WIP2 (2025-04-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -561,7 +561,7 @@
 !mmm     do m3mgdInjuryFX(cOwnID, 0, effEnduranceLoss / cOwnID.(m3mgdGetEnduranceAttribute(cOwnID)).max)
 !mmm   end if
 !mmm   if attackResult >= 20 and not isfumble(cAttackRoll)
-!mmm     do m3mgdChatDefensePrompt(cTargetID, cOwnID, cWeaponType, "ranged")
+!mmm     do m3mgdChatDefensePrompt(attackData)
 !mmm   end if
 !mmm
 !mmm end script

--- a/examples/midgard/rangedAttack/rangedAttack.mmm
+++ b/examples/midgard/rangedAttack/rangedAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Ranged Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "2.1.0pre (2025-04-17)"
+!mmm   set scriptVersion = "2.1.0 (2025-04-17)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion

--- a/examples/midgard/rangedAttack/rangedAttack.mmm
+++ b/examples/midgard/rangedAttack/rangedAttack.mmm
@@ -1,7 +1,7 @@
 !rem // Midgard Ranged Attack Script
 !rem //
 !mmm script
-!mmm   set scriptVersion = "2.0.1 (2024-11-17)"
+!mmm   set scriptVersion = "2.1.0WIP (2025-04-16)"
 !mmm
 !mmm   set customizable cCheckVersion = false
 !mmm   if cCheckVersion
@@ -425,7 +425,11 @@
 !mmm
 !rem   // Save key attack data for defense script
 !mmm   if attackResult >= 20 and not isfumble(cAttackRoll) and damageResult > 0
-!mmm     if not m3mgdExchangeStoreAttack("ranged") 
+!mmm     set attackData = { origin: cOwnID.token_id, target: cTargetID.token_id, action: "combatAttack", attackType: "ranged", attackResult: attackResult, criticalAttack: criticalAttack, damageResult: damageResult, damageRoll: cDamageRoll, weaponType: cWeaponType }
+!mmm     if cMagicEnduranceCost
+!mmm       set attackData = { attackData, magicEnduranceCost: cMagicEnduranceCost }
+!mmm     end if
+!mmm     if not m3mgdStoreAttack(attackData) 
 !mmm       do whisperback("Problem bei der Datenablage für das Abwehrskript; Angriffsdaten bitte manuell ergänzen.")
 !mmm     end if
 !mmm   end if

--- a/examples/midgard/tools/exchangeRegEdit.mmm
+++ b/examples/midgard/tools/exchangeRegEdit.mmm
@@ -1,4 +1,6 @@
 !rem // exchangeRegEdit
+!rem //
+!rem // last revision 2025-04-03
 !rem
 !mmm script
 !mmm   set customizable cmd = default

--- a/examples/midgard/tools/exchangeRegEdit.mmm
+++ b/examples/midgard/tools/exchangeRegEdit.mmm
@@ -5,6 +5,7 @@
 !mmm script
 !mmm   set customizable cmd = default
 !mmm   set customizable deleteConfirm = false
+!mmm   set customizable newTarget = default
 !mmm   set customizable searchByAction = default
 !mmm   set customizable searchByOrigin = default
 !mmm   set customizable searchByTarget = default
@@ -19,7 +20,17 @@
 %{MacroSheetLibrary|libExchange}
 !mmm   do _libExchange()
 !mmm
-!mmm   if cmd eq "deleteEntry" and deleteConfirm == true and (searchByAction and searchByOrigin and searchByTarget)
+!mmm   if cmd eq "editEntry" and newTarget and searchByAction and searchByAttackType and searchByAttackResult and searchByDamageResult
+!mmm
+!mmm     set searchCriteria = { action: searchByAction, attackType: searchByAttackType, attackResult: searchByAttackResult, damageResult: searchByDamageResult }
+!mmm     if not isdefault(searchByMagicSpell)
+!mmm       set searchCriteria = { searchCriteria, magicSpell: searchByMagicSpell }
+!mmm     end if
+!mmm     do m3mgdExchangeEditEntry(dataExchangeID, searchCriteria, { target: newTarget })
+!mmm     set sender = newTarget.token_id
+!mmm     chat: [Abwehr gegen Frostball von ](~MacroSheet|defend${searchByMagicSpell})
+!mmm
+!mmm   else if cmd eq "deleteEntry" and deleteConfirm == true and (searchByAction and searchByOrigin and searchByTarget)
 !mmm
 !mmm     set searchCriteria = { action: searchByAction, origin: searchByOrigin, target: searchByTarget }
 !mmm     if not isdefault(searchByAttackType)
@@ -34,7 +45,7 @@
 !mmm     if not isdefault(searchByMagicSpell)
 !mmm       set searchCriteria = { searchCriteria, magicSpell: searchByMagicSpell }
 !mmm     end if
-!mmm     do m3mgdExchangeDeleteEntry(dataExchangeID, searchCriteria)
+!mmm     do m3mgdExchangeDelete(dataExchangeID, searchCriteria)
 !mmm     do m3mgdExchangeRegEdit(dataExchangeID)
 !mmm
 !mmm   else 

--- a/examples/midgard/tools/exchangeRegEdit.mmm
+++ b/examples/midgard/tools/exchangeRegEdit.mmm
@@ -1,0 +1,47 @@
+!rem // exchangeRegEdit
+!rem
+!mmm script
+!mmm   set customizable cmd = default
+!mmm   set customizable deleteConfirm = false
+!mmm   set customizable searchByAction = default
+!mmm   set customizable searchByOrigin = default
+!mmm   set customizable searchByTarget = default
+!mmm   set customizable searchByAttackType = default
+!mmm   set customizable searchByAttackResult = default
+!mmm   set customizable searchByMagicSpell = default
+!mmm   set customizable searchByDamageResult = default
+!mmm
+!mmm   set m3mgdScriptCommands = { m3mgdScriptCommands, exchangeRegEdit: "&#x25;{MacroSheet|exchangeRegEdit}" }
+!mmm   set dataExchangeID = "m3mgdTestCombatExchange"
+!mmm
+%{MacroSheetLibrary|libExchange}
+!mmm   do _libExchange()
+!mmm   
+!mmm   debug chat: libExchange loaded and initialized.
+!mmm
+!mmm
+!mmm   if cmd eq "deleteEntry" and deleteConfirm == true and (searchByAction and searchByOrigin and searchByTarget)
+!mmm
+!mmm     set searchCriteria = { action: searchByAction, origin: searchByOrigin, target: searchByTarget }
+!mmm     if not isdefault(searchByAttackType)
+!mmm       set searchCriteria = { searchCriteria, attackType: searchByAttackType }
+!mmm     end if
+!mmm     if not isdefault(searchByAttackResult)
+!mmm       set searchCriteria = { searchCriteria, attackResult: searchByAttackResult }
+!mmm     end if
+!mmm     if not isdefault(searchByDamageResult)
+!mmm       set searchCriteria = { searchCriteria, damageResult: searchByDamageResult }
+!mmm     end if
+!mmm     if not isdefault(searchByMagicSpell)
+!mmm       set searchCriteria = { searchCriteria, magicSpell: searchByMagicSpell }
+!mmm     end if
+!mmm     do m3mgdExchangeDeleteEntry(dataExchangeID, searchCriteria)
+!mmm     do m3mgdExchangeRegEdit(dataExchangeID)
+!mmm
+!mmm   else 
+!mmm
+!mmm     do m3mgdExchangeRegEdit(dataExchangeID)
+!mmm
+!mmm   end if
+!mmm
+!mmm end script

--- a/examples/midgard/tools/exchangeRegEdit.mmm
+++ b/examples/midgard/tools/exchangeRegEdit.mmm
@@ -1,6 +1,6 @@
 !rem // exchangeRegEdit
 !rem //
-!rem // last revision 2025-04-03
+!rem // last revision 2025-04-16
 !rem
 !mmm script
 !mmm   set customizable cmd = default
@@ -14,13 +14,10 @@
 !mmm   set customizable searchByDamageResult = default
 !mmm
 !mmm   set m3mgdScriptCommands = { m3mgdScriptCommands, exchangeRegEdit: "&#x25;{MacroSheet|exchangeRegEdit}" }
-!mmm   set dataExchangeID = "m3mgdTestCombatExchange"
+!mmm   set dataExchangeID = m3mgdExchangeRegistries.combatData
 !mmm
 %{MacroSheetLibrary|libExchange}
 !mmm   do _libExchange()
-!mmm   
-!mmm   debug chat: libExchange loaded and initialized.
-!mmm
 !mmm
 !mmm   if cmd eq "deleteEntry" and deleteConfirm == true and (searchByAction and searchByOrigin and searchByTarget)
 !mmm


### PR DESCRIPTION
Implements https://github.com/phylll/mychs-macro-magic/issues/64 as a basis for https://github.com/phylll/mychs-macro-magic/issues/65 (& https://github.com/phylll/mychs-macro-magic/issues/88) and https://github.com/phylll/mychs-macro-magic/issues/86 for typical combat sequences (making melee/ranged/magic attacks & defending against them). 

The new data exchange has an editor script for manual inspection/cleanup and is a bit smarter than the old one in identifying incomplete data from context.

Along the way, fixed a few smaller bugs.