### PR TITLE
Flatten lists passed to `min()` and `max()` into their arguments

### DIFF
--- a/MychsMacroMagic.js
+++ b/MychsMacroMagic.js
@@ -1,7 +1,7 @@
 // Mych's Macro Magic by Michael Buschbeck <michael@buschbeck.net> (2021)
 // https://github.com/michael-buschbeck/mychs-macro-magic/blob/main/LICENSE
 
-const MMM_VERSION = "1.37.1";
+const MMM_VERSION = "1.37.2";
 
 const MMM_STARTUP_INSTANCE = MMM_VERSION + "/" + new Date().toISOString();
 const MMM_STARTUP_SENDER = "MMM-f560287b-c9a0-4273-bf03-f2c1f97d24d4";
@@ -763,17 +763,16 @@ class MychScriptContext extends MychStash
         for (let argIndex = 0; argIndex < arguments.length; ++argIndex)
         {
             let argValue = arguments[argIndex];
+            let argValueList = MychExpression.coerceList(argValue);
             
-            if (argValue == undefined)
+            for (let argValueItem of argValueList)
             {
-                continue;
-            }
+                argValueItem = MychExpression.coerceNumber(argValueItem);
 
-            argValue = MychExpression.coerceNumber(argValue);
-
-            if (minValue == undefined || minValue > argValue)
-            {
-                minValue = argValue;
+                if (minValue == undefined || minValue > argValueItem)
+                {
+                    minValue = argValueItem;
+                }
             }
         }
 
@@ -787,17 +786,16 @@ class MychScriptContext extends MychStash
         for (let argIndex = 0; argIndex < arguments.length; ++argIndex)
         {
             let argValue = arguments[argIndex];
+            let argValueList = MychExpression.coerceList(argValue);
             
-            if (argValue == undefined)
+            for (let argValueItem of argValueList)
             {
-                continue;
-            }
+                argValueItem = MychExpression.coerceNumber(argValueItem);
 
-            argValue = MychExpression.coerceNumber(argValue);
-            
-            if (maxValue == undefined || maxValue < argValue)
-            {
-                maxValue = argValue;
+                if (maxValue == undefined || maxValue < argValueItem)
+                {
+                    maxValue = argValueItem;
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -1026,8 +1026,8 @@ This works in any place with an expression, of course, not just in **set** – y
 | round(*a*)                                         | Math      | round(1.5) = 2   | Round *a* to the nearest integer
 | ceil(*a*)                                          | Math      | ceil(1.3) = 2    | Return the smallest integer that's greater than or equal to *a*
 | abs(*a*)                                           | Math      | abs(-5) = 5      | Return the absolute value of *a*
-| min(...)                                           | Math      | min(3,1,2) = 1   | Return the numerically smallest value – any number of arguments allowed
-| max(...)                                           | Math      | max(3,1,2) = 3   | Return the numerically greatest value – any number of arguments allowed
+| min(...)                                           | Math      | min(3,1,2) = 1   | Return the numerically smallest value – any number of arguments allowed, lists in arguments are flattened
+| max(...)                                           | Math      | max(3,1,2) = 3   | Return the numerically greatest value – any number of arguments allowed, lists in arguments are flattened
 | sin(*degrees*)                                     | Math      | sin(90) = 1      | Return the sine of *degrees*
 | cos(*degrees*)                                     | Math      | cos(90) = 0      | Return the cosine of *degrees*
 | tan(*degrees*)                                     | Math      | tan(45) = 1      | Return the tangent of *degrees*

--- a/test/expressions.html
+++ b/test/expressions.html
@@ -985,15 +985,31 @@
                 { result: "-456" },
             ],
             [
-                "min(5, undefined, 'moo', 999, 2, -3.14)",
+                "min(5, undef, 'moo', 999, 2, -3.14)",
                 { result: "-3.14" },
+            ],
+            [
+                "min((4, 2, 1, -99, 5, 3) select ...)",
+                { result: "-99" },
+            ],
+            [
+                "min((4, 2, 1, -99, 5, 3) select ..., (1, 2, -999, 3) select ...)",
+                { result: "-999" },
             ],
             [
                 "max()",
                 { result: "undef" },
             ],
             [
-                "max(5, undefined, 'moo', 999, 2, -3.14)",
+                "max(5, undef, 'moo', 999, 2, -3.14)",
+                { result: "999" },
+            ],
+            [
+                "max((4, 2, 1, 99, 5, 3) select ...)",
+                { result: "99" },
+            ],
+            [
+                "max((4, 2, 1, 99, 5, 3) select ..., (1, 2, 999, 3) select ...)",
                 { result: "999" },
             ],
             [


### PR DESCRIPTION
Version: 1.37.2
Resolves: #246